### PR TITLE
feature(fxconfig): add mtls support for fxconfig namespace list

### DIFF
--- a/tools/fxconfig/cmd/namespace/list.go
+++ b/tools/fxconfig/cmd/namespace/list.go
@@ -9,33 +9,46 @@ package namespace
 import (
 	"io"
 
+	"github.com/hyperledger/fabric-x-common/cmd/common/comm"
+
 	"github.com/spf13/cobra"
 )
 
-type listFunc func(out io.Writer, endpoint, cacert string) error
+type listFunc func(out io.Writer, endpoint string, tlsConfig comm.Config) error
 
 func newListCommand(listFunc listFunc) *cobra.Command {
 	// this is our default query service endpoint
 	endpoint := "localhost:7001"
-	cacert := ""
+	var tlsConfig comm.Config
 
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List installed Namespaces",
 		Long:  "",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return listFunc(cmd.OutOrStdout(), endpoint, cacert)
+			return listFunc(cmd.OutOrStdout(), endpoint, tlsConfig)
 		},
 	}
 
-	cmd.PersistentFlags().StringVarP(&cacert,
+	cmd.PersistentFlags().StringVarP(&tlsConfig.PeerCACertPath,
 		"cafile",
 		"",
 		"",
-		"Path to file containing PEM-encoded trusted certificate(s) for the committer query service endpoint",
+		"Path to file containing PEM-encoded trusted certificate(s) for the committer",
 	)
 
-	// TODO: add client crt / key for mTLS support
+	cmd.PersistentFlags().StringVarP(&tlsConfig.KeyPath,
+		"keyfile",
+		"",
+		"",
+		"Path to file containing PEM-encoded private key to use for mutual TLS communication with the committer",
+	)
+	cmd.PersistentFlags().StringVarP(&tlsConfig.CertPath,
+		"certfile",
+		"",
+		"",
+		"Path to file containing PEM-encoded public key to use for mutual TLS communication with the committer",
+	)
 
 	cmd.PersistentFlags().StringVar(
 		&endpoint,

--- a/tools/fxconfig/cmd/namespace/list_test.go
+++ b/tools/fxconfig/cmd/namespace/list_test.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"testing"
 
+	"github.com/hyperledger/fabric-x-common/cmd/common/comm"
+
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
@@ -38,7 +40,7 @@ func setupList(t *testing.T) *cobra.Command {
 	return rootCmd
 }
 
-var fakeList = func(_ io.Writer, _, _ string) error {
+var fakeList = func(_ io.Writer, _ string, _ comm.Config) error {
 	// don't do anything
 	return nil
 }

--- a/tools/fxconfig/internal/namespace/list.go
+++ b/tools/fxconfig/internal/namespace/list.go
@@ -19,10 +19,8 @@ import (
 )
 
 // List calls the committer query service and shows all installed namespace policies.
-func List(out io.Writer, endpoint, cacert string) error {
-	cl, err := comm.NewClient(comm.Config{
-		PeerCACertPath: cacert,
-	})
+func List(out io.Writer, endpoint string, tlsConfig comm.Config) error {
+	cl, err := comm.NewClient(tlsConfig)
 	if err != nil {
 		return fmt.Errorf("cannot get grpc client: %w", err)
 	}


### PR DESCRIPTION
This PR adds flags for keypath and certpath for `fxconfig namespace list` to establish a mutual TLS connection with the committer query service.

```bash
❯ ./fxconfig namespace list --help
List installed Namespaces

Usage:
  fxconfig namespace list [flags]

Flags:
      --cafile string     Path to file containing PEM-encoded trusted certificate(s) for the committer
      --certfile string   Path to file containing PEM-encoded public key to use for mutual TLS communication with the committer
      --endpoint string   committer query service endpoint
  -h, --help              help for list
      --keyfile string    Path to file containing PEM-encoded private key to use for mutual TLS communication with the committer
```