### PR TITLE
use `CMD` instead of `ENTRYPOINT` in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,5 +61,5 @@ LABEL name="fabric-x-tools" \
 USER 10001
 WORKDIR /home/fabricx
 
-# Default Entrypoint
-ENTRYPOINT ["/bin/sh"]
+# Define default CMD
+CMD ["/bin/sh"]


### PR DESCRIPTION
<!--
Copyright IBM Corp. All Rights Reserved.

SPDX-License-Identifier: Apache-2.0

DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST.

If this PR introduces a breaking change that affects compatibility with other components:
- The PR title must begin with the prefix [BREAKING].
- "Breaking change" must be included in the list below.
- Relevant stakeholders must be notified before or immediately after the PR is merged.
-->
#### Type of change

<!--- What type of change? Pick one or more options and delete the others. -->
- Bug fix

#### Description

<!--- Describe your changes in detail, including motivation. -->

Changing from `ENTRYPOINT` to `CMD` to allow easier run of CLI tools. For example:

```shell
podman run --rm fabric-x-tools:latest configtxgen
```

instead of

```shell
podman run --rm --entrypoint configtxgen fabric-x-tools:0.0.7
```
