### PR TITLE
add committer and orderer maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,12 +4,20 @@
 
 **Active Maintainers**
 
-| Name                 | GitHub                           | Chat            | email                         |
-| -------------------- | -------------------------------- | --------------- | ----------------------------- |
-| Ilie Circiumaru      | [iliecirciumaru][iliecirciumaru] | Ilie Circiumaru | <ici@zurich.ibm.com>          |
-| Marcus Brandenburger | [mbrandenburger][mbrandenburger] | bur             | <bur@zurich.ibm.com>          |
-| Pasquale Convertini  | [pasquale95][pasquale95]         | paskelo95       | <Pasquale.Convertini@ibm.com> |
+| Name                   | GitHub                           | Chat            | email                         |
+| ---------------------- | -------------------------------- | --------------- | ----------------------------- |
+| Hagar Meir             | [HagarMeir][HagarMeir]           | HagarMeir       | <hagar.meir@ibm.com>          |
+| Ilie Circiumaru        | [iliecirciumaru][iliecirciumaru] | Ilie Circiumaru | <ici@zurich.ibm.com>          |
+| Liran Funaro           | [liran-funaro][liran-funaro]     | liran-funaro    | <liran.funaro@ibm.com>        |
+| Marcus Brandenburger   | [mbrandenburger][mbrandenburger] | bur             | <bur@zurich.ibm.com>          |
+| Pasquale Convertini    | [pasquale95][pasquale95]         | paskelo95       | <Pasquale.Convertini@ibm.com> |
+| Senthilnathan Natarajan | [cendhu][cendhu]                | cendhu          | <cendhu@gmail.com>            |
+| Yoav Tock              | [tock-ibm][tock-ibm]             | tock-ibm        | <tock@il.ibm.com>             |
 
-[mbrandenburger]: https://github.com/mbrandenburger
+[cendhu]: https://github.com/cendhu
+[HagarMeir]: https://github.com/HagarMeir
 [iliecirciumaru]: https://github.com/iliecirciumaru
+[liran-funaro]: https://github.com/liran-funaro
+[mbrandenburger]: https://github.com/mbrandenburger
 [pasquale95]: https://github.com/pasquale95
+[tock-ibm]: https://github.com/tock-ibm


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

Both orderer and committer team will manage the integration test in this repository. We will also host the fabric-x documentation here.

#### Additional details (Optional)

Once this PR is merged, necessary updates should be made to governance repo too. 