### PR TITLE
 Add TLS integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ generate: FORCE
 .PHONY: test
 test: FORCE
 	@echo "Running Go unit tests..."
-	cd tools && $(go_test) ./... | go tool gotestfmt ${GO_TEST_FMT_FLAGS}
+	@set -o pipefail; \
+	cd tools && $(go_test) ./... | (go tool gotestfmt ${GO_TEST_FMT_FLAGS} || cat)
 
 .PHONY: $(TOOLS_EXES)
 $(TOOLS_EXES): %: $(BUILD_DIR)/% ## Builds a native binary

--- a/tools/fxconfig/integration/helpers_test.go
+++ b/tools/fxconfig/integration/helpers_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -34,6 +35,14 @@ const (
 	sidecarPort      = "4001"
 	queryServicePort = "7001"
 	channelID        = "mychannel"
+
+	eventuallyTimeout = 10 * time.Second
+	eventuallyTick    = 100 * time.Millisecond
+
+	policyArg  = "--policy=AND('Org1MSP.member', 'Org2MSP.member')"
+	endorseArg = "--endorse"
+	submitArg  = "--submit"
+	waitArg    = "--wait"
 )
 
 // setupSingleOrgAdmin spawns a committer test container with a single org admin lifecycle policy
@@ -54,7 +63,7 @@ func setupSingleOrgAdminWithTLS(t *testing.T) map[string]string {
 	genesisPath, err := filepath.Abs(filepath.Join(".", "testdata", "crypto", "single-org.pb.bin"))
 	require.NoError(t, err)
 
-	return setupWithTLS(t, genesisPath, true)
+	return setupWithTLS(t, genesisPath)
 }
 
 // setupMultiOrgAdmin spawns a committer test container with a multi org admin lifecycle policy
@@ -75,15 +84,74 @@ func setupMultiOrgAdminWithTLS(t *testing.T) map[string]string {
 	genesisPath, err := filepath.Abs(filepath.Join(".", "testdata", "crypto", "multi-org.pb.bin"))
 	require.NoError(t, err)
 
-	return setupWithTLS(t, genesisPath, true)
+	return setupWithTLS(t, genesisPath)
 }
 
 func setup(t *testing.T, genesisPath string) map[string]string {
 	t.Helper()
-	return setupWithTLS(t, genesisPath, false)
+
+	dataDirectory, err := filepath.Abs(filepath.Join(".", "testdata", "crypto"))
+	require.NoError(t, err)
+
+	// msp configuration for sidecar orderer client
+	mspID := "Org1MSP"
+	mspDir := "/root/artifacts/crypto/peerOrganizations/Org1/users/committer@org1.com/msp"
+
+	ctx := t.Context()
+	committerContainer, err := testcontainers.Run(
+		ctx, "ghcr.io/hyperledger/fabric-x-committer-test-node:0.1.9",
+		testcontainers.WithCmd("run", "db", "orderer", "committer", "--insecure"),
+		testcontainers.WithFiles(testcontainers.ContainerFile{
+			HostFilePath:      genesisPath,
+			ContainerFilePath: "/root/artifacts/config-block.pb.bin",
+			FileMode:          0o700,
+		}),
+		testcontainers.WithFiles(testcontainers.ContainerFile{
+			HostFilePath:      dataDirectory,
+			ContainerFilePath: "/root/artifacts/",
+			FileMode:          0o755,
+		}),
+		testcontainers.WithExposedPorts(ordererPort, sidecarPort, queryServicePort),
+		testcontainers.WithEnv(map[string]string{
+			"SC_COORDINATOR_LOGGING_LOGSPEC":      "DEBUG",
+			"SC_SIDECAR_LOGGING_LOGSPEC":          "DEBUG",
+			"SC_SIDECAR_ORDERER_CHANNEL_ID":       channelID,
+			"SC_SIDECAR_ORDERER_TLS_MODE":         "none",
+			"SC_SIDECAR_ORDERER_SIGNED_ENVELOPES": "true",
+			"SC_SIDECAR_ORDERER_IDENTITY_MSP_ID":  mspID,
+			"SC_SIDECAR_ORDERER_IDENTITY_MSP_DIR": mspDir,
+			"SC_QUERY_SERVICE_SERVER_ENDPOINT":    fmt.Sprintf(":%v", queryServicePort),
+			"SC_QUERY_SERVICE_LOGGING_LOGSPEC":    "DEBUG",
+			"SC_ORDERER_BLOCK_SIZE":               "1",
+			"SC_ORDERER_LOGGING_LOGSPEC":          "DEBUG",
+			"SC_VC_LOGGING_LOGSPEC":               "DEBUG",
+		}),
+		testcontainers.WithWaitStrategy(
+			wait.ForListeningPort(ordererPort),
+			wait.ForListeningPort(sidecarPort),
+			wait.ForListeningPort(queryServicePort),
+			wait.ForLog("Setting the last committed block number:"),
+		),
+	)
+	t.Cleanup(func() {
+		testcontainers.CleanupContainer(t, committerContainer)
+	})
+	require.NoError(t, err)
+
+	endpoints := make(map[string]string)
+	endpoints["query"], err = committerContainer.PortEndpoint(ctx, queryServicePort, "")
+	require.NoError(t, err)
+
+	endpoints["orderer"], err = committerContainer.PortEndpoint(ctx, ordererPort, "")
+	require.NoError(t, err)
+
+	endpoints["sidecar"], err = committerContainer.PortEndpoint(ctx, sidecarPort, "")
+	require.NoError(t, err)
+
+	return endpoints
 }
 
-func setupWithTLS(t *testing.T, genesisPath string, enableTLS bool) map[string]string {
+func setupWithTLS(t *testing.T, genesisPath string) map[string]string {
 	t.Helper()
 
 	dataDirectory, err := filepath.Abs(filepath.Join(".", "testdata", "crypto"))
@@ -98,6 +166,7 @@ func setupWithTLS(t *testing.T, genesisPath string, enableTLS bool) map[string]s
 		"SC_COORDINATOR_LOGGING_LOGSPEC":      "DEBUG",
 		"SC_SIDECAR_LOGGING_LOGSPEC":          "DEBUG",
 		"SC_SIDECAR_ORDERER_CHANNEL_ID":       channelID,
+		"SC_SIDECAR_ORDERER_TLS_MODE":         "tls",
 		"SC_SIDECAR_ORDERER_SIGNED_ENVELOPES": "true",
 		"SC_SIDECAR_ORDERER_IDENTITY_MSP_ID":  mspID,
 		"SC_SIDECAR_ORDERER_IDENTITY_MSP_DIR": mspDir,
@@ -106,39 +175,32 @@ func setupWithTLS(t *testing.T, genesisPath string, enableTLS bool) map[string]s
 		"SC_ORDERER_BLOCK_SIZE":               "1",
 		"SC_ORDERER_LOGGING_LOGSPEC":          "DEBUG",
 		"SC_VC_LOGGING_LOGSPEC":               "DEBUG",
+
+		"SC_ORDERER_SERVER_TLS_MODE":      "tls",
+		"SC_ORDERER_SERVER_TLS_CERT_PATH": "/root/artifacts/crypto/ordererOrganizations/OrdererOrg/orderers/orderer.orderer.com/tls/server.crt",
+		"SC_ORDERER_SERVER_TLS_KEY_PATH":  "/root/artifacts/crypto/ordererOrganizations/OrdererOrg/orderers/orderer.orderer.com/tls/key.crt",
+
+		"SC_QUERY_SERVICE_SERVER_TLS_MODE":          "tls",
+		"SC_QUERY_SERVICE_SERVER_TLS_CERT_PATH":     "/root/artifacts/crypto/peerOrganizations/Org1/peers/committer.org1.com/tls/server.crt",
+		"SC_QUERY_SERVICE_SERVER_TLS_KEY_PATH":      "/root/artifacts/crypto/peerOrganizations/Org1/peers/committer.org1.com/tls/server.key",
+		"SC_SIDECAR_SERVER_TLS_MODE":                "tls",
+		"SC_SIDECAR_SERVER_TLS_CERT_PATH":           "/root/artifacts/crypto/peerOrganizations/Org1/peers/committer.org1.com/tls/server.crt",
+		"SC_SIDECAR_SERVER_TLS_KEY_PATH":            "/root/artifacts/crypto/peerOrganizations/Org1/peers/committer.org1.com/tls/server.key",
+		"SC_ORDERER_SERVER_TLS_CA_CERT_PATHS":       "",
+		"SC_QUERY_SERVICE_SERVER_TLS_CA_CERT_PATHS": "",
+		"SC_SIDECAR_SERVER_TLS_CA_CERT_PATHS":       "",
 	}
 
-	// Configure TLS settings
-	if enableTLS {
-		// TLS configuration for orderer
-		envVars["SC_SIDECAR_ORDERER_TLS_MODE"] = "tls"
-		envVars["SC_ORDERER_SERVER_TLS_MODE"] = "tls"
-		envVars["SC_ORDERER_SERVER_TLS_CERT_PATH"] = "/root/artifacts/crypto/ordererOrganizations/OrdererOrg/orderers/orderer.orderer.com/tls/server.crt"
-		envVars["SC_ORDERER_SERVER_TLS_KEY_PATH"] = "/root/artifacts/crypto/ordererOrganizations/OrdererOrg/orderers/orderer.orderer.com/tls/key.crt"
-		
-		// TLS CA certificate paths - using correct array syntax
-		caCertPaths := []string{
-			"/root/artifacts/crypto/peerOrganizations/Org1/tlsca/tlsca.org1.com-cert.pem",
-			"/root/artifacts/crypto/peerOrganizations/Org1/tlsca/tlsca.org2.com-cert.pem",
-			"/root/artifacts/crypto/peerOrganizations/Org1/tlsca/tlsca.org3.com-cert.pem",
-			"/root/artifacts/crypto/ordererOrganizations/OrdererOrg/tlsca/tlsca.orderer.com-cert.pem",
-		}
-		envVars["SC_ORDERER_SERVER_TLS_CA_CERT_PATHS"] = fmt.Sprintf("[%s]", strings.Join(caCertPaths, ","))
-		
-		// Query service TLS configuration
-		envVars["SC_QUERY_SERVICE_SERVER_TLS_MODE"] = "tls"
-		envVars["SC_QUERY_SERVICE_SERVER_TLS_CERT_PATH"] = "/root/artifacts/crypto/peerOrganizations/Org1/peers/committer.org1.com/tls/server.crt"
-		envVars["SC_QUERY_SERVICE_SERVER_TLS_KEY_PATH"] = "/root/artifacts/crypto/peerOrganizations/Org1/peers/committer.org1.com/tls/server.key"
-		envVars["SC_QUERY_SERVICE_SERVER_TLS_CA_CERT_PATHS"] = fmt.Sprintf("[%s]", strings.Join(caCertPaths, ","))
-		
-		// Sidecar TLS configuration
-		envVars["SC_SIDECAR_SERVER_TLS_MODE"] = "tls"
-		envVars["SC_SIDECAR_SERVER_TLS_CERT_PATH"] = "/root/artifacts/crypto/peerOrganizations/Org1/peers/committer.org1.com/tls/server.crt"
-		envVars["SC_SIDECAR_SERVER_TLS_KEY_PATH"] = "/root/artifacts/crypto/peerOrganizations/Org1/peers/committer.org1.com/tls/server.key"
-		envVars["SC_SIDECAR_SERVER_TLS_CA_CERT_PATHS"] = fmt.Sprintf("[%s]", strings.Join(caCertPaths, ","))
-	} else {
-		envVars["SC_SIDECAR_ORDERER_TLS_MODE"] = "none"
+	caCertPaths := []string{
+		"/root/artifacts/crypto/peerOrganizations/Org1/tlsca/tlsca.org1.com-cert.pem",
+		"/root/artifacts/crypto/peerOrganizations/Org2/tlsca/tlsca.org2.com-cert.pem",
+		"/root/artifacts/crypto/peerOrganizations/Org3/tlsca/tlsca.org3.com-cert.pem",
+		"/root/artifacts/crypto/ordererOrganizations/OrdererOrg/tlsca/tlsca.orderer.com-cert.pem",
 	}
+	caCerts := fmt.Sprintf("[%s]", strings.Join(caCertPaths, ","))
+	envVars["SC_ORDERER_SERVER_TLS_CA_CERT_PATHS"] = caCerts
+	envVars["SC_QUERY_SERVICE_SERVER_TLS_CA_CERT_PATHS"] = caCerts
+	envVars["SC_SIDECAR_SERVER_TLS_CA_CERT_PATHS"] = caCerts
 
 	ctx := t.Context()
 	committerContainer, err := testcontainers.Run(
@@ -200,19 +262,21 @@ func generateConfigFileWithTLS(
 	tb.Helper()
 	tmpDir := tb.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
-	
-	tlsConfig := ""
+
+	tlsEnabled := "false"
 	if enableTLS {
-		tlsConfig = `
+		tlsEnabled = "true"
+	}
+
+	tlsConfig := fmt.Sprintf(`
   tls:
-    enabled: true
+    enabled: %s
     rootCertPaths:
       - ./testdata/crypto/peerOrganizations/Org1/tlsca/tlsca.org1.com-cert.pem
-      - ./testdata/crypto/peerOrganizations/Org1/tlsca/tlsca.org2.com-cert.pem
-      - ./testdata/crypto/peerOrganizations/Org1/tlsca/tlsca.org3.com-cert.pem
-      - ./testdata/crypto/ordererOrganizations/OrdererOrg/tlsca/tlsca.orderer.com-cert.pem`
-	}
-	
+      - ./testdata/crypto/peerOrganizations/Org2/tlsca/tlsca.org2.com-cert.pem
+      - ./testdata/crypto/peerOrganizations/Org3/tlsca/tlsca.org3.com-cert.pem
+      - ./testdata/crypto/ordererOrganizations/OrdererOrg/tlsca/tlsca.orderer.com-cert.pem`, tlsEnabled)
+
 	configContent := `
 msp:
   localMspID: ` + localMspID + `

--- a/tools/fxconfig/integration/helpers_test.go
+++ b/tools/fxconfig/integration/helpers_test.go
@@ -47,7 +47,17 @@ func setupSingleOrgAdmin(t *testing.T) map[string]string {
 	return setup(t, genesisPath)
 }
 
-// setupSingleOrgAdmin spawns a committer test container with a single org admin lifecycle policy
+// setupSingleOrgAdminWithTLS spawns a committer test container with TLS enabled
+func setupSingleOrgAdminWithTLS(t *testing.T) map[string]string {
+	t.Helper()
+
+	genesisPath, err := filepath.Abs(filepath.Join(".", "testdata", "crypto", "single-org.pb.bin"))
+	require.NoError(t, err)
+
+	return setupWithTLS(t, genesisPath, true)
+}
+
+// setupMultiOrgAdmin spawns a committer test container with a multi org admin lifecycle policy
 // and returns a map containing the endpoints of the committers services.
 func setupMultiOrgAdmin(t *testing.T) map[string]string {
 	t.Helper()
@@ -58,7 +68,22 @@ func setupMultiOrgAdmin(t *testing.T) map[string]string {
 	return setup(t, genesisPath)
 }
 
+// setupMultiOrgAdminWithTLS spawns a committer test container with TLS enabled
+func setupMultiOrgAdminWithTLS(t *testing.T) map[string]string {
+	t.Helper()
+
+	genesisPath, err := filepath.Abs(filepath.Join(".", "testdata", "crypto", "multi-org.pb.bin"))
+	require.NoError(t, err)
+
+	return setupWithTLS(t, genesisPath, true)
+}
+
 func setup(t *testing.T, genesisPath string) map[string]string {
+	t.Helper()
+	return setupWithTLS(t, genesisPath, false)
+}
+
+func setupWithTLS(t *testing.T, genesisPath string, enableTLS bool) map[string]string {
 	t.Helper()
 
 	dataDirectory, err := filepath.Abs(filepath.Join(".", "testdata", "crypto"))
@@ -67,6 +92,53 @@ func setup(t *testing.T, genesisPath string) map[string]string {
 	// msp configuration for sidecar orderer client
 	mspID := "Org1MSP"
 	mspDir := "/root/artifacts/crypto/peerOrganizations/Org1/users/committer@org1.com/msp"
+
+	// Base environment configuration
+	envVars := map[string]string{
+		"SC_COORDINATOR_LOGGING_LOGSPEC":      "DEBUG",
+		"SC_SIDECAR_LOGGING_LOGSPEC":          "DEBUG",
+		"SC_SIDECAR_ORDERER_CHANNEL_ID":       channelID,
+		"SC_SIDECAR_ORDERER_SIGNED_ENVELOPES": "true",
+		"SC_SIDECAR_ORDERER_IDENTITY_MSP_ID":  mspID,
+		"SC_SIDECAR_ORDERER_IDENTITY_MSP_DIR": mspDir,
+		"SC_QUERY_SERVICE_SERVER_ENDPOINT":    fmt.Sprintf(":%v", queryServicePort),
+		"SC_QUERY_SERVICE_LOGGING_LOGSPEC":    "DEBUG",
+		"SC_ORDERER_BLOCK_SIZE":               "1",
+		"SC_ORDERER_LOGGING_LOGSPEC":          "DEBUG",
+		"SC_VC_LOGGING_LOGSPEC":               "DEBUG",
+	}
+
+	// Configure TLS settings
+	if enableTLS {
+		// TLS configuration for orderer
+		envVars["SC_SIDECAR_ORDERER_TLS_MODE"] = "tls"
+		envVars["SC_ORDERER_SERVER_TLS_MODE"] = "tls"
+		envVars["SC_ORDERER_SERVER_TLS_CERT_PATH"] = "/root/artifacts/crypto/ordererOrganizations/OrdererOrg/orderers/orderer.orderer.com/tls/server.crt"
+		envVars["SC_ORDERER_SERVER_TLS_KEY_PATH"] = "/root/artifacts/crypto/ordererOrganizations/OrdererOrg/orderers/orderer.orderer.com/tls/key.crt"
+		
+		// TLS CA certificate paths - using correct array syntax
+		caCertPaths := []string{
+			"/root/artifacts/crypto/peerOrganizations/Org1/tlsca/tlsca.org1.com-cert.pem",
+			"/root/artifacts/crypto/peerOrganizations/Org1/tlsca/tlsca.org2.com-cert.pem",
+			"/root/artifacts/crypto/peerOrganizations/Org1/tlsca/tlsca.org3.com-cert.pem",
+			"/root/artifacts/crypto/ordererOrganizations/OrdererOrg/tlsca/tlsca.orderer.com-cert.pem",
+		}
+		envVars["SC_ORDERER_SERVER_TLS_CA_CERT_PATHS"] = fmt.Sprintf("[%s]", strings.Join(caCertPaths, ","))
+		
+		// Query service TLS configuration
+		envVars["SC_QUERY_SERVICE_SERVER_TLS_MODE"] = "tls"
+		envVars["SC_QUERY_SERVICE_SERVER_TLS_CERT_PATH"] = "/root/artifacts/crypto/peerOrganizations/Org1/peers/committer.org1.com/tls/server.crt"
+		envVars["SC_QUERY_SERVICE_SERVER_TLS_KEY_PATH"] = "/root/artifacts/crypto/peerOrganizations/Org1/peers/committer.org1.com/tls/server.key"
+		envVars["SC_QUERY_SERVICE_SERVER_TLS_CA_CERT_PATHS"] = fmt.Sprintf("[%s]", strings.Join(caCertPaths, ","))
+		
+		// Sidecar TLS configuration
+		envVars["SC_SIDECAR_SERVER_TLS_MODE"] = "tls"
+		envVars["SC_SIDECAR_SERVER_TLS_CERT_PATH"] = "/root/artifacts/crypto/peerOrganizations/Org1/peers/committer.org1.com/tls/server.crt"
+		envVars["SC_SIDECAR_SERVER_TLS_KEY_PATH"] = "/root/artifacts/crypto/peerOrganizations/Org1/peers/committer.org1.com/tls/server.key"
+		envVars["SC_SIDECAR_SERVER_TLS_CA_CERT_PATHS"] = fmt.Sprintf("[%s]", strings.Join(caCertPaths, ","))
+	} else {
+		envVars["SC_SIDECAR_ORDERER_TLS_MODE"] = "none"
+	}
 
 	ctx := t.Context()
 	committerContainer, err := testcontainers.Run(
@@ -83,20 +155,7 @@ func setup(t *testing.T, genesisPath string) map[string]string {
 			FileMode:          0o755,
 		}),
 		testcontainers.WithExposedPorts(ordererPort, sidecarPort, queryServicePort),
-		testcontainers.WithEnv(map[string]string{
-			"SC_COORDINATOR_LOGGING_LOGSPEC":      "DEBUG",
-			"SC_SIDECAR_LOGGING_LOGSPEC":          "DEBUG",
-			"SC_SIDECAR_ORDERER_CHANNEL_ID":       channelID,
-			"SC_SIDECAR_ORDERER_TLS_MODE":         "none",
-			"SC_SIDECAR_ORDERER_SIGNED_ENVELOPES": "true",
-			"SC_SIDECAR_ORDERER_IDENTITY_MSP_ID":  mspID,
-			"SC_SIDECAR_ORDERER_IDENTITY_MSP_DIR": mspDir,
-			"SC_QUERY_SERVICE_SERVER_ENDPOINT":    fmt.Sprintf(":%v", queryServicePort),
-			"SC_QUERY_SERVICE_LOGGING_LOGSPEC":    "DEBUG",
-			"SC_ORDERER_BLOCK_SIZE":               "1",
-			"SC_ORDERER_LOGGING_LOGSPEC":          "DEBUG",
-			"SC_VC_LOGGING_LOGSPEC":               "DEBUG",
-		}),
+		testcontainers.WithEnv(envVars),
 		testcontainers.WithWaitStrategy(
 			wait.ForListeningPort(ordererPort),
 			wait.ForListeningPort(sidecarPort),
@@ -128,9 +187,32 @@ func generateConfigFile(
 	mspConfigPath string,
 	endpoints map[string]string,
 ) string {
+	return generateConfigFileWithTLS(tb, localMspID, mspConfigPath, endpoints, false)
+}
+
+func generateConfigFileWithTLS(
+	tb testing.TB,
+	localMspID string,
+	mspConfigPath string,
+	endpoints map[string]string,
+	enableTLS bool,
+) string {
 	tb.Helper()
 	tmpDir := tb.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
+	
+	tlsConfig := ""
+	if enableTLS {
+		tlsConfig = `
+  tls:
+    enabled: true
+    rootCertPaths:
+      - ./testdata/crypto/peerOrganizations/Org1/tlsca/tlsca.org1.com-cert.pem
+      - ./testdata/crypto/peerOrganizations/Org1/tlsca/tlsca.org2.com-cert.pem
+      - ./testdata/crypto/peerOrganizations/Org1/tlsca/tlsca.org3.com-cert.pem
+      - ./testdata/crypto/ordererOrganizations/OrdererOrg/tlsca/tlsca.orderer.com-cert.pem`
+	}
+	
 	configContent := `
 msp:
   localMspID: ` + localMspID + `
@@ -139,16 +221,16 @@ msp:
 orderer:
   address: ` + endpoints["orderer"] + `
   channel: ` + channelID + `
-  connectionTimeout: 30s
+  connectionTimeout: 30s` + tlsConfig + `
 
 queries:
   address: ` + endpoints["query"] + `
-  connectionTimeout: 20s
+  connectionTimeout: 20s` + tlsConfig + `
 
 notifications:
   address: ` + endpoints["sidecar"] + `
   connectionTimeout: 15s
-  waitingTimeout: 15s
+  waitingTimeout: 15s` + tlsConfig + `
 `
 	err := os.WriteFile(configPath, []byte(configContent), 0o600)
 	require.NoError(tb, err)

--- a/tools/fxconfig/integration/single_org_test.go
+++ b/tools/fxconfig/integration/single_org_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,15 +24,7 @@ import (
 //go:generate go tool configtxgen --configPath testdata --channelID mychannel --profile MultiOrgAdminChannel --outputBlock testdata/crypto/multi-org.pb.bin
 
 const (
-	eventuallyTimeout = 10 * time.Second
-	eventuallyTick    = 100 * time.Millisecond
-
 	scaleTestNamespaceCount = 50 // test with many namespaces
-
-	policyArg  = "--policy=AND('Org1MSP.member', 'Org2MSP.member')"
-	endorseArg = "--endorse"
-	submitArg  = "--submit"
-	waitArg    = "--wait"
 )
 
 //nolint:maintidx // large by design: one container shared across many subtests

--- a/tools/fxconfig/integration/tls_test.go
+++ b/tools/fxconfig/integration/tls_test.go
@@ -1,0 +1,280 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package integration_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	eventuallyTimeout = 10 * time.Second
+	eventuallyTick    = 100 * time.Millisecond
+
+	policyArg         = "--policy=AND('Org1MSP.member', 'Org2MSP.member')"
+	policyAnd2of2TLS  = "--policy=AND('Org1MSP.member', 'Org2MSP.member')"
+	endorseArg        = "--endorse"
+	submitArg         = "--submit"
+	waitArg           = "--wait"
+)
+
+func TestSingleOrgTLSScenarios(t *testing.T) {
+	endpoints := setupSingleOrgAdminWithTLS(t)
+
+	t.Logf("TLS endpoints: %v", endpoints)
+
+	testdata, err := filepath.Abs(filepath.Join(".", "testdata"))
+	require.NoError(t, err)
+
+	// endorser MSP configuration
+	org1MspPath := filepath.Join(testdata, "crypto", "peerOrganizations", "Org1", "users", "endorser@org1.com", "msp")
+	org1Config := generateConfigFileWithTLS(t, "Org1MSP", org1MspPath, endpoints, true)
+
+	configArg := "--config=" + org1Config
+
+	t.Run("create_new_namespace_msp_tls", func(t *testing.T) {
+		t.Parallel()
+
+		expectedNs := Namespace{Name: "hello_msp_tls", Version: 0}
+
+		// we expect no namespaces
+		stdOut, err := fxconfig(t, "namespace", "list", configArg)
+		require.NoError(t, err)
+		nss, err := parseNamespaceList(stdOut)
+		require.NoError(t, err)
+		require.NotContains(t, nss, expectedNs)
+
+		// create namespace hello
+		_, err = fxconfig(t, "namespace", "create", expectedNs.Name,
+			configArg, policyArg, endorseArg, submitArg)
+		require.NoError(t, err)
+
+		// expect one installed namespace
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			stdOut, err := fxconfig(t, "namespace", "list", configArg)
+			require.NoError(ct, err)
+			nss, err := parseNamespaceList(stdOut)
+			require.NoError(ct, err)
+			require.Contains(ct, nss, expectedNs)
+		}, eventuallyTimeout, eventuallyTick)
+	})
+
+	t.Run("create_new_namespace_with_wait_tls", func(t *testing.T) {
+		t.Parallel()
+
+		expectedNs := Namespace{Name: "hello_with_wait_tls", Version: 0}
+
+		// we expect no namespaces
+		stdOut, err := fxconfig(t, "namespace", "list", configArg)
+		require.NoError(t, err)
+		nss, err := parseNamespaceList(stdOut)
+		require.NoError(t, err)
+		require.NotContains(t, nss, expectedNs)
+
+		// create namespace hello
+		_, err = fxconfig(t, "namespace", "create", expectedNs.Name,
+			configArg, policyArg, endorseArg, submitArg, waitArg)
+		require.NoError(t, err)
+
+		// expect one installed namespace
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			stdOut, err := fxconfig(t, "namespace", "list", configArg)
+			require.NoError(ct, err)
+			nss, err := parseNamespaceList(stdOut)
+			require.NoError(ct, err)
+			require.Contains(ct, nss, expectedNs)
+		}, eventuallyTimeout, eventuallyTick)
+	})
+
+	t.Run("update_namespace_tls", func(t *testing.T) {
+		t.Parallel()
+
+		expectedNs := Namespace{Name: "ns1_tls", Version: 0}
+
+		// we expect this namespace not to exist
+		stdOut, err := fxconfig(t, "namespace", "list", configArg)
+		require.NoError(t, err)
+		nss, err := parseNamespaceList(stdOut)
+		require.NoError(t, err)
+		require.NotContains(t, nss, expectedNs)
+
+		// create namespace
+		_, err = fxconfig(t, "namespace", "create", expectedNs.Name,
+			configArg, policyArg, endorseArg, submitArg)
+		require.NoError(t, err)
+
+		// we expect our namespace to be created
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			stdOut, err = fxconfig(t, "namespace", "list", configArg)
+			require.NoError(ct, err)
+			nss, err = parseNamespaceList(stdOut)
+			require.NoError(ct, err)
+			require.Contains(ct, nss, expectedNs)
+		}, eventuallyTimeout, eventuallyTick)
+
+		// we need to set the current version
+		versionArg := "--version=0"
+
+		// update namespace
+		expectedNs = Namespace{Name: "ns1_tls", Version: 1}
+		_, err = fxconfig(t, "namespace", "update", expectedNs.Name,
+			configArg, versionArg, policyArg, endorseArg, submitArg)
+		require.NoError(t, err)
+
+		// we expect our namespace to be updated having a version equals 1
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			stdOut, err = fxconfig(t, "namespace", "list", configArg)
+			require.NoError(ct, err)
+			nss, err = parseNamespaceList(stdOut)
+			require.NoError(ct, err)
+			require.Contains(ct, nss, expectedNs)
+		}, eventuallyTimeout, eventuallyTick)
+	})
+}
+
+func TestMultiOrgTLSScenarios(t *testing.T) {
+	endpoints := setupMultiOrgAdminWithTLS(t)
+
+	t.Logf("TLS endpoints: %v", endpoints)
+
+	testdata, err := filepath.Abs(filepath.Join(".", "testdata"))
+	require.NoError(t, err)
+
+	org1MspPath := filepath.Join(testdata, "crypto", "peerOrganizations", "Org1", "users", "endorser@org1.com", "msp")
+	org2MspPath := filepath.Join(testdata, "crypto", "peerOrganizations", "Org2", "users", "endorser@org2.com", "msp")
+
+	org1Config := generateConfigFileWithTLS(t, "Org1MSP", org1MspPath, endpoints, true)
+	org2Config := generateConfigFileWithTLS(t, "Org2MSP", org2MspPath, endpoints, true)
+
+	t.Run("multi_org_create_2of2_tls", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		txFile := filepath.Join(tmpDir, "tx.json")
+		txOrg1 := filepath.Join(tmpDir, "tx_org1.json")
+		txOrg2 := filepath.Join(tmpDir, "tx_org2.json")
+		merged := filepath.Join(tmpDir, "merged.json")
+		ns := "m1_create_2of2_tls"
+		policy := policyAnd2of2TLS
+
+		_, err := fxconfig(t, "namespace", "create", ns, "--config="+org1Config, policy, "--output="+txFile)
+		require.NoError(t, err)
+
+		_, err = fxconfig(t, "tx", "endorse", txFile, "--config="+org1Config, "--output="+txOrg1)
+		require.NoError(t, err)
+
+		_, err = fxconfig(t, "tx", "endorse", txFile, "--config="+org2Config, "--output="+txOrg2)
+		require.NoError(t, err)
+
+		_, err = fxconfig(t, "tx", "merge", txOrg1, txOrg2, "--output="+merged)
+		require.NoError(t, err)
+
+		_, err = fxconfig(t, "tx", "submit", merged, "--config="+org1Config)
+		require.NoError(t, err)
+
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			stdOut, err := fxconfig(t, "namespace", "list", "--config="+org1Config)
+			require.NoError(ct, err)
+			nss, err := parseNamespaceList(stdOut)
+			require.NoError(ct, err)
+			require.Contains(ct, nss, Namespace{Name: ns, Version: 0})
+		}, eventuallyTimeout, eventuallyTick)
+	})
+
+	t.Run("multi_org_create_2of2_with_wait_tls", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		txFile := filepath.Join(tmpDir, "tx.json")
+		txOrg1 := filepath.Join(tmpDir, "tx_org1.json")
+		txOrg2 := filepath.Join(tmpDir, "tx_org2.json")
+		merged := filepath.Join(tmpDir, "merged.json")
+		ns := "m2_create_2of2_wait_tls"
+		policy := policyAnd2of2TLS
+
+		_, err := fxconfig(t, "namespace", "create", ns, "--config="+org1Config, policy, "--output="+txFile)
+		require.NoError(t, err)
+
+		_, err = fxconfig(t, "tx", "endorse", txFile, "--config="+org1Config, "--output="+txOrg1)
+		require.NoError(t, err)
+
+		_, err = fxconfig(t, "tx", "endorse", txFile, "--config="+org2Config, "--output="+txOrg2)
+		require.NoError(t, err)
+
+		_, err = fxconfig(t, "tx", "merge", txOrg1, txOrg2, "--output="+merged)
+		require.NoError(t, err)
+
+		stdOut, err := fxconfig(t, "tx", "submit", "--wait", merged, "--config="+org1Config)
+		require.NoError(t, err)
+		require.Contains(t, stdOut, "Transaction status: COMMITTED", "stdout: %s", stdOut)
+
+		stdOut, err = fxconfig(t, "namespace", "list", "--config="+org1Config)
+		require.NoError(t, err)
+		nss, err := parseNamespaceList(stdOut)
+		require.NoError(t, err)
+		require.Contains(t, nss, Namespace{Name: ns, Version: 0})
+	})
+
+	t.Run("multi_org_update_tls", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		txFile := filepath.Join(tmpDir, "tx.json")
+		txOrg1 := filepath.Join(tmpDir, "tx_org1.json")
+		txOrg2 := filepath.Join(tmpDir, "tx_org2.json")
+		merged := filepath.Join(tmpDir, "merged.json")
+		updateFile := filepath.Join(tmpDir, "update.json")
+		updateOrg1 := filepath.Join(tmpDir, "update_org1.json")
+		updateOrg2 := filepath.Join(tmpDir, "update_org2.json")
+		updateMerged := filepath.Join(tmpDir, "update_merged.json")
+		ns := "m5_update_tls"
+		policy := policyAnd2of2TLS
+
+		// Create the namespace first using the 2-of-2 pipeline with --wait
+		_, err := fxconfig(t, "namespace", "create", ns, "--config="+org1Config, policy, "--output="+txFile)
+		require.NoError(t, err)
+
+		_, err = fxconfig(t, "tx", "endorse", txFile, "--config="+org1Config, "--output="+txOrg1)
+		require.NoError(t, err)
+
+		_, err = fxconfig(t, "tx", "endorse", txFile, "--config="+org2Config, "--output="+txOrg2)
+		require.NoError(t, err)
+
+		_, err = fxconfig(t, "tx", "merge", txOrg1, txOrg2, "--output="+merged)
+		require.NoError(t, err)
+
+		_, err = fxconfig(t, "tx", "submit", "--wait", merged, "--config="+org1Config)
+		require.NoError(t, err)
+
+		// Now update the namespace
+		_, err = fxconfig(t, "namespace", "update", ns,
+			"--config="+org1Config, policy, "--version=0", "--output="+updateFile)
+		require.NoError(t, err)
+
+		_, err = fxconfig(t, "tx", "endorse", updateFile, "--config="+org1Config, "--output="+updateOrg1)
+		require.NoError(t, err)
+
+		_, err = fxconfig(t, "tx", "endorse", updateFile, "--config="+org2Config, "--output="+updateOrg2)
+		require.NoError(t, err)
+
+		_, err = fxconfig(t, "tx", "merge", updateOrg1, updateOrg2, "--output="+updateMerged)
+		require.NoError(t, err)
+
+		_, err = fxconfig(t, "tx", "submit", "--wait", updateMerged, "--config="+org1Config)
+		require.NoError(t, err)
+
+		stdOut, err := fxconfig(t, "namespace", "list", "--config="+org1Config)
+		require.NoError(t, err)
+		nss, err := parseNamespaceList(stdOut)
+		require.NoError(t, err)
+		require.Contains(t, nss, Namespace{Name: ns, Version: 1})
+	})
+}

--- a/tools/fxconfig/integration/tls_test.go
+++ b/tools/fxconfig/integration/tls_test.go
@@ -9,22 +9,12 @@ package integration_test
 import (
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	eventuallyTimeout = 10 * time.Second
-	eventuallyTick    = 100 * time.Millisecond
-
-	policyArg         = "--policy=AND('Org1MSP.member', 'Org2MSP.member')"
-	policyAnd2of2TLS  = "--policy=AND('Org1MSP.member', 'Org2MSP.member')"
-	endorseArg        = "--endorse"
-	submitArg         = "--submit"
-	waitArg           = "--wait"
-)
+const policyAnd2of2TLS = "--policy=AND('Org1MSP.member', 'Org2MSP.member')"
 
 func TestSingleOrgTLSScenarios(t *testing.T) {
 	endpoints := setupSingleOrgAdminWithTLS(t)


### PR DESCRIPTION
- Fix TLS CA certificate paths syntax from indexed to array format
- Correct TLS key path from server.key to key.crt per issue spec
- Add TLS support for orderer, query, and sidecar services
- Add comprehensive TLS integration test suite 

Fixes #62
 