### PR TITLE
fix(fxconfig): support meta namespace updates

### DIFF
--- a/tools/fxconfig/integration/single_org_test.go
+++ b/tools/fxconfig/integration/single_org_test.go
@@ -480,4 +480,33 @@ func TestSingleOrgScenarios(t *testing.T) {
 			require.Contains(ct, nss, Namespace{Name: ns, Version: 1})
 		}, eventuallyTimeout, eventuallyTick)
 	})
+
+	t.Run("create_after_meta_namespace_version_update", func(t *testing.T) {
+		t.Parallel()
+
+		sourceNs := "s9_meta_update_source"
+		targetNs := "s9_meta_update_target"
+
+		// Create and commit the source namespace.
+		_, err := fxconfig(t, "namespace", "create", sourceNs,
+			configArg, policyArg, endorseArg, submitArg, waitArg)
+		require.NoError(t, err)
+
+		// Update and commit the source namespace, which updates the meta namespace version.
+		_, err = fxconfig(t, "namespace", "update", sourceNs,
+			configArg, policyArg, "--version=0", endorseArg, submitArg, waitArg)
+		require.NoError(t, err)
+
+		// A new namespace creation should still succeed with the updated meta namespace version.
+		_, err = fxconfig(t, "namespace", "create", targetNs,
+			configArg, policyArg, endorseArg, submitArg, waitArg)
+		require.NoError(t, err)
+
+		stdOut, err := fxconfig(t, "namespace", "list", configArg)
+		require.NoError(t, err)
+		nss, err := parseNamespaceList(stdOut)
+		require.NoError(t, err)
+		require.Contains(t, nss, Namespace{Name: sourceNs, Version: 1})
+		require.Contains(t, nss, Namespace{Name: targetNs, Version: 0})
+	})
 }

--- a/tools/fxconfig/internal/app/create.go
+++ b/tools/fxconfig/internal/app/create.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/transaction"
 )
 
@@ -21,18 +22,53 @@ const (
 
 // CreateNamespace generates a namespace transaction without endorsement or submission.
 // Returns transaction ID and unsigned transaction for later processing.
-func (*AdminApp) CreateNamespace(_ context.Context, input *DeployNamespaceInput) (*DeployNamespaceOutput, error) {
+func (d *AdminApp) CreateNamespace(ctx context.Context, input *DeployNamespaceInput) (*DeployNamespaceOutput, error) {
 	nsPolicy, err := createPolicy(input.Policy)
+	if err != nil {
+		return nil, err
+	}
+
+	metaNsVersion, err := d.metaNamespaceVersion(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	out := &DeployNamespaceOutput{
 		TxID: transaction.GenerateTxID(),
-		Tx:   transaction.CreateNamespacesTx(nsPolicy, input.NsID, input.Version),
+		Tx:   transaction.CreateNamespacesTx(nsPolicy, input.NsID, input.Version, metaNsVersion),
 	}
 
 	return out, nil
+}
+
+// metaNamespaceVersion returns the current version of the meta namespace.
+func (d *AdminApp) metaNamespaceVersion(ctx context.Context) (uint64, error) {
+	if d.QueryProvider == nil {
+		return 0, fmt.Errorf("query provider is required")
+	}
+
+	qc, err := d.QueryProvider.Get()
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		_ = qc.Close()
+	}()
+
+	res, err := qc.GetNamespacePolicies(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("cannot query existing namespaces: %w", err)
+	}
+
+	for _, p := range res.GetPolicies() {
+		if p.GetNamespace() == committerpb.MetaNamespaceID {
+			return p.GetVersion(), nil
+		}
+	}
+
+	// On fresh networks the meta namespace policy may not be listed yet.
+	// In that case, start with version 0 and let subsequent updates advance it.
+	return 0, nil
 }
 
 // createPolicy creates a namespace policy from configuration.

--- a/tools/fxconfig/internal/app/deploy_test.go
+++ b/tools/fxconfig/internal/app/deploy_test.go
@@ -11,7 +11,18 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/adapters"
+	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/config"
+	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/provider"
 )
+
+func makeMetaNamespaceQueryProvider(version uint64) *provider.Provider[adapters.QueryClient, *config.QueriesConfig] {
+	return makeQueryProvider(&mockQueryClient{policies: &applicationpb.NamespacePolicies{Policies: []*applicationpb.PolicyItem{
+		{Namespace: "_meta", Version: version, Policy: []byte("meta-policy")},
+	}}}, nil)
+}
 
 func TestDeployNamespaceInputValidate(t *testing.T) {
 	t.Parallel()
@@ -78,7 +89,7 @@ func TestDeployNamespaceInputValidate(t *testing.T) {
 func TestDeployNamespace_CreateOnly(t *testing.T) {
 	t.Parallel()
 
-	a := &AdminApp{Validators: fakeValidationContext()}
+	a := &AdminApp{Validators: fakeValidationContext(), QueryProvider: makeMetaNamespaceQueryProvider(0)}
 	input := &DeployNamespaceInput{
 		NsID:    "testns",
 		Version: -1,
@@ -95,10 +106,35 @@ func TestDeployNamespace_CreateOnly(t *testing.T) {
 	require.Equal(t, UnknownStatus, status)
 }
 
+func TestDeployNamespace_CreateOnly_NoMetaNamespacePresent(t *testing.T) {
+	t.Parallel()
+
+	a := &AdminApp{
+		Validators:    fakeValidationContext(),
+		QueryProvider: makeQueryProvider(&mockQueryClient{policies: &applicationpb.NamespacePolicies{}}, nil),
+	}
+	input := &DeployNamespaceInput{
+		NsID:    "testns",
+		Version: -1,
+		Policy:  PolicyConfig{Type: mspPolicyType, MSP: &MSPPolicyConfig{Expression: "OR('Org1MSP.member')"}},
+		Endorse: false,
+		Submit:  false,
+	}
+
+	out, status, err := a.DeployNamespace(t.Context(), input)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotEmpty(t, out.TxID)
+	require.NotNil(t, out.Tx)
+	require.Len(t, out.Tx.Namespaces, 1)
+	require.Equal(t, uint64(0), out.Tx.Namespaces[0].NsVersion)
+	require.Equal(t, UnknownStatus, status)
+}
+
 func TestDeployNamespace_ValidationError(t *testing.T) {
 	t.Parallel()
 
-	a := &AdminApp{Validators: fakeValidationContext()}
+	a := &AdminApp{Validators: fakeValidationContext(), QueryProvider: makeMetaNamespaceQueryProvider(0)}
 	input := &DeployNamespaceInput{
 		NsID:    "testns",
 		Version: -2, // invalid
@@ -121,8 +157,9 @@ func TestDeployNamespace_EndorseOnly(t *testing.T) {
 	t.Parallel()
 
 	a := &AdminApp{
-		Validators:  fakeValidationContext(),
-		MspProvider: makeMSPProvider(&testSigningIdentity{}, nil),
+		Validators:    fakeValidationContext(),
+		QueryProvider: makeMetaNamespaceQueryProvider(0),
+		MspProvider:   makeMSPProvider(&testSigningIdentity{}, nil),
 	}
 	input := validDeployInput()
 	input.Endorse = true
@@ -141,8 +178,9 @@ func TestDeployNamespace_EndorseError(t *testing.T) {
 	t.Parallel()
 
 	a := &AdminApp{
-		Validators:  fakeValidationContext(),
-		MspProvider: makeMSPProvider(nil, errors.New("msp not configured")),
+		Validators:    fakeValidationContext(),
+		QueryProvider: makeMetaNamespaceQueryProvider(0),
+		MspProvider:   makeMSPProvider(nil, errors.New("msp not configured")),
 	}
 	input := validDeployInput()
 	input.Endorse = true
@@ -156,6 +194,7 @@ func TestDeployNamespace_EndorseAndSubmit(t *testing.T) {
 
 	a := &AdminApp{
 		Validators:      fakeValidationContext(),
+		QueryProvider:   makeMetaNamespaceQueryProvider(0),
 		MspProvider:     makeMSPProvider(&testSigningIdentity{}, nil),
 		OrdererProvider: makeOrdererProvider(&mockOrdererClient{}, nil),
 	}
@@ -175,6 +214,7 @@ func TestDeployNamespace_EndorseAndSubmitError(t *testing.T) {
 
 	a := &AdminApp{
 		Validators:      fakeValidationContext(),
+		QueryProvider:   makeMetaNamespaceQueryProvider(0),
 		MspProvider:     makeMSPProvider(&testSigningIdentity{}, nil),
 		OrdererProvider: makeOrdererProvider(&mockOrdererClient{broadcastErr: errors.New("orderer unavailable")}, nil),
 	}
@@ -194,6 +234,7 @@ func TestDeployNamespace_EndorseAndSubmitWithWait(t *testing.T) {
 
 	a := &AdminApp{
 		Validators:           fakeValidationContext(),
+		QueryProvider:        makeMetaNamespaceQueryProvider(0),
 		MspProvider:          makeMSPProvider(&testSigningIdentity{}, nil),
 		OrdererProvider:      makeOrdererProvider(&mockOrdererClient{}, nil),
 		NotificationProvider: makeNotificationProvider(&mockNotificationClient{status: expectedStatus}, nil),
@@ -214,6 +255,7 @@ func TestDeployNamespace_EndorseAndSubmitWithWaitError(t *testing.T) {
 
 	a := &AdminApp{
 		Validators:           fakeValidationContext(),
+		QueryProvider:        makeMetaNamespaceQueryProvider(0),
 		MspProvider:          makeMSPProvider(&testSigningIdentity{}, nil),
 		OrdererProvider:      makeOrdererProvider(&mockOrdererClient{}, nil),
 		NotificationProvider: makeNotificationProvider(nil, errors.New("notification service unavailable")),

--- a/tools/fxconfig/internal/transaction/namespace.go
+++ b/tools/fxconfig/internal/transaction/namespace.go
@@ -14,11 +14,10 @@ import (
 
 // CreateNamespacesTx builds a transaction to create or update a namespace policy.
 // Writes to the meta-namespace. Use version -1 for create, >= 0 for update.
-func CreateNamespacesTx(nsPolicy *applicationpb.NamespacePolicy, nsID string, nsVersion int) *applicationpb.Tx {
+func CreateNamespacesTx(nsPolicy *applicationpb.NamespacePolicy, nsID string, nsVersion int, metaNsVersion uint64) *applicationpb.Tx {
 	writeToMetaNs := &applicationpb.TxNamespace{
-		NsId: committerpb.MetaNamespaceID,
-		// TODO: we need the correct version of the metaNamespaceID
-		NsVersion:  0,
+		NsId:       committerpb.MetaNamespaceID,
+		NsVersion:  metaNsVersion,
 		ReadWrites: make([]*applicationpb.ReadWrite, 0, 1),
 	}
 

--- a/tools/fxconfig/internal/transaction/namespace_test.go
+++ b/tools/fxconfig/internal/transaction/namespace_test.go
@@ -28,32 +28,36 @@ func TestCreateNamespacesTx(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		nsPolicy    *applicationpb.NamespacePolicy
-		nsID        string
-		nsVersion   int
-		description string
+		name          string
+		nsPolicy      *applicationpb.NamespacePolicy
+		nsID          string
+		nsVersion     int
+		metaNsVersion uint64
+		description   string
 	}{
 		{
-			name:        "create new namespace (version -1)",
-			nsPolicy:    nsPolicy,
-			nsID:        "new-namespace",
-			nsVersion:   -1,
-			description: "Should create transaction for new namespace",
+			name:          "create new namespace (version -1)",
+			nsPolicy:      nsPolicy,
+			nsID:          "new-namespace",
+			nsVersion:     -1,
+			metaNsVersion: 0,
+			description:   "Should create transaction for new namespace",
 		},
 		{
-			name:        "update existing namespace (version 0)",
-			nsPolicy:    nsPolicy,
-			nsID:        "existing-namespace",
-			nsVersion:   0,
-			description: "Should create transaction for namespace update",
+			name:          "update existing namespace (version 0)",
+			nsPolicy:      nsPolicy,
+			nsID:          "existing-namespace",
+			nsVersion:     0,
+			metaNsVersion: 1,
+			description:   "Should create transaction for namespace update",
 		},
 		{
-			name:        "update existing namespace (version 5)",
-			nsPolicy:    nsPolicy,
-			nsID:        "existing-namespace",
-			nsVersion:   5,
-			description: "Should create transaction for namespace update with higher version",
+			name:          "update existing namespace (version 5)",
+			nsPolicy:      nsPolicy,
+			nsID:          "existing-namespace",
+			nsVersion:     5,
+			metaNsVersion: 9,
+			description:   "Should create transaction for namespace update with higher version",
 		},
 	}
 
@@ -61,14 +65,14 @@ func TestCreateNamespacesTx(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := CreateNamespacesTx(tt.nsPolicy, tt.nsID, tt.nsVersion)
+			result := CreateNamespacesTx(tt.nsPolicy, tt.nsID, tt.nsVersion, tt.metaNsVersion)
 
 			require.NotNil(t, result, tt.description)
 			require.Len(t, result.Namespaces, 1, "Should have one namespace entry")
 
 			ns := result.Namespaces[0]
 			require.Equal(t, "_meta", ns.NsId, "Should target meta-namespace")
-			require.Equal(t, uint64(0), ns.NsVersion, "Meta-namespace version should be 0")
+			require.Equal(t, tt.metaNsVersion, ns.NsVersion, "Meta-namespace version should match input")
 			require.Len(t, ns.ReadWrites, 1, "Should have one read-write entry")
 
 			rw := ns.ReadWrites[0]


### PR DESCRIPTION
<!--
Copyright IBM Corp. All Rights Reserved.

SPDX-License-Identifier: Apache-2.0

DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST.

If this PR introduces a breaking change that affects compatibility with other components:
- The PR title must begin with the prefix [BREAKING].
- "Breaking change" must be included in the list below.
- Relevant stakeholders must be notified before or immediately after the PR is merged.
-->
#### Type of change

<!--- What type of change? Pick one or more options and delete the others. -->
- Bug fix
- Improvement (improvement to code, performance, etc)
- Test update

#### Description

<!--- Describe your changes in detail, including motivation. -->

This fixes #61 by removing the hardcoded _meta namespace version in namespace create/update tx generation.

fxconfig now reads the current _meta version from query results and uses it when building the transaction, so namespace operations still work after config/meta updates.
If _meta is not present yet (fresh network), it falls back to version 0 so first-time namespace creation still works.

Also added/updated tests for dynamic meta version handling and the no-_meta bootstrap case.


#### Additional details (Optional)

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated Github issue -->
#61 