### PR TITLE
feat(fxconfig): add configurable bccsp for msp signer

### DIFF
--- a/tools/fxconfig/docs/README.md
+++ b/tools/fxconfig/docs/README.md
@@ -93,6 +93,13 @@ Configuration is loaded from multiple sources with the following precedence (hig
 msp:
   localMspID: Org1MSP
   configPath: /path/to/msp
+  bccsp:
+    default: SW
+    sw:
+      security: 256
+      hash: SHA2
+      fileKeyStore:
+        keyStorePath: /path/to/msp/keystore
 
 # Logging configuration
 logging:
@@ -279,6 +286,13 @@ cat > org1-config.yaml <<EOF
 msp:
   localMspID: Org1MSP
   configPath: /opt/org1/msp
+  bccsp:
+    default: SW
+    sw:
+      security: 256
+      hash: SHA2
+      fileKeyStore:
+        keyStorePath: /opt/org1/msp/keystore
 orderer:
   address: orderer.example.com:7050
   tls:

--- a/tools/fxconfig/docs/README.md
+++ b/tools/fxconfig/docs/README.md
@@ -148,6 +148,31 @@ notifications:
     enabled: false
 ```
 
+### BCCSP / HSM (PKCS#11)
+
+By default fxconfig uses the software BCCSP with a file-based keystore. To
+sign with keys stored in an HSM (or any PKCS#11 token such as SoftHSM2),
+build fxconfig with `-tags pkcs11` and configure the `msp.bccsp.pkcs11`
+section:
+
+```yaml
+msp:
+  localMspID: Org1MSP
+  configPath: /path/to/msp
+  bccsp:
+    pkcs11:
+      library: /usr/local/lib/libsofthsm2.so
+      label: TokenLabel
+      pin: ${HSM_PIN}
+      hash: SHA2       # optional, defaults to SHA2
+      security: 256    # optional, defaults to 256
+      softwareVerify: true  # optional
+```
+
+When `pkcs11.library` is non-empty, the signer loads keys from the HSM and
+the `sw` / `fileKeyStore` section is ignored. Without `-tags pkcs11` the
+`pkcs11` block is accepted but has no effect (the SW provider is used).
+
 ### TLS Configuration
 
 - **No TLS**: `enabled: false` or all TLS fields empty

--- a/tools/fxconfig/internal/config/bccsp_nopkcs11.go
+++ b/tools/fxconfig/internal/config/bccsp_nopkcs11.go
@@ -1,0 +1,17 @@
+//go:build !pkcs11
+
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
+)
+
+// applyPKCS11Opts is a no-op when fxconfig is built without the pkcs11 tag.
+// PKCS#11 support is opt-in and requires building with -tags pkcs11.
+func applyPKCS11Opts(_ *factory.FactoryOpts, _ BCCSPPKCS11Config) {}

--- a/tools/fxconfig/internal/config/bccsp_nopkcs11_test.go
+++ b/tools/fxconfig/internal/config/bccsp_nopkcs11_test.go
@@ -1,0 +1,38 @@
+//go:build !pkcs11
+
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMSPConfigToFactoryOpts_PKCS11_IgnoredWithoutTag verifies that PKCS#11
+// configuration is a no-op when the binary is built without -tags pkcs11.
+// The SW provider remains the default.
+func TestMSPConfigToFactoryOpts_PKCS11_IgnoredWithoutTag(t *testing.T) {
+	t.Parallel()
+
+	mspCfg := MSPConfig{
+		ConfigPath: "/tmp/msp",
+		BCCSP: BCCSPConfig{
+			PKCS11: BCCSPPKCS11Config{
+				Library: "/usr/local/lib/libsofthsm2.so",
+				Label:   "TestLabel",
+				Pin:     "1234",
+			},
+		},
+	}
+
+	opts := mspCfg.ToFactoryOpts()
+
+	require.Equal(t, "SW", opts.Default)
+	require.NotNil(t, opts.SW)
+}

--- a/tools/fxconfig/internal/config/bccsp_pkcs11.go
+++ b/tools/fxconfig/internal/config/bccsp_pkcs11.go
@@ -1,0 +1,35 @@
+//go:build pkcs11
+
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"cmp"
+
+	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
+	"github.com/hyperledger/fabric-lib-go/bccsp/pkcs11"
+)
+
+// applyPKCS11Opts maps fxconfig PKCS#11 settings onto the Fabric factory options.
+// When BCCSP.PKCS11.Library is set the factory is switched to the PKCS11 provider.
+func applyPKCS11Opts(opts *factory.FactoryOpts, cfg BCCSPPKCS11Config) {
+	if cfg.Library == "" {
+		return
+	}
+
+	opts.Default = "PKCS11"
+	opts.PKCS11 = &pkcs11.PKCS11Opts{
+		Library:        cfg.Library,
+		Label:          cfg.Label,
+		Pin:            cfg.Pin,
+		Hash:           cmp.Or(cfg.Hash, "SHA2"),
+		Security:       cmp.Or(cfg.Security, 256),
+		SoftwareVerify: cfg.SoftwareVerify,
+		Immutable:      cfg.Immutable,
+	}
+}

--- a/tools/fxconfig/internal/config/bccsp_pkcs11_test.go
+++ b/tools/fxconfig/internal/config/bccsp_pkcs11_test.go
@@ -1,0 +1,84 @@
+//go:build pkcs11
+
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMSPConfigToFactoryOpts_PKCS11(t *testing.T) {
+	t.Parallel()
+
+	mspCfg := MSPConfig{
+		ConfigPath: "/tmp/msp",
+		BCCSP: BCCSPConfig{
+			PKCS11: BCCSPPKCS11Config{
+				Library:        "/usr/local/lib/libsofthsm2.so",
+				Label:          "TestLabel",
+				Pin:            "1234",
+				Hash:           "SHA2",
+				Security:       256,
+				SoftwareVerify: true,
+			},
+		},
+	}
+
+	opts := mspCfg.ToFactoryOpts()
+
+	require.Equal(t, "PKCS11", opts.Default)
+	require.NotNil(t, opts.PKCS11)
+	require.Equal(t, "/usr/local/lib/libsofthsm2.so", opts.PKCS11.Library)
+	require.Equal(t, "TestLabel", opts.PKCS11.Label)
+	require.Equal(t, "1234", opts.PKCS11.Pin)
+	require.Equal(t, "SHA2", opts.PKCS11.Hash)
+	require.Equal(t, 256, opts.PKCS11.Security)
+	require.True(t, opts.PKCS11.SoftwareVerify)
+}
+
+func TestMSPConfigToFactoryOpts_PKCS11_DefaultsWhenLibrarySet(t *testing.T) {
+	t.Parallel()
+
+	mspCfg := MSPConfig{
+		ConfigPath: "/tmp/msp",
+		BCCSP: BCCSPConfig{
+			PKCS11: BCCSPPKCS11Config{
+				Library: "/usr/local/lib/libsofthsm2.so",
+				Label:   "TestLabel",
+				Pin:     "1234",
+			},
+		},
+	}
+
+	opts := mspCfg.ToFactoryOpts()
+
+	require.Equal(t, "PKCS11", opts.Default)
+	require.NotNil(t, opts.PKCS11)
+	require.Equal(t, "SHA2", opts.PKCS11.Hash)
+	require.Equal(t, 256, opts.PKCS11.Security)
+}
+
+func TestMSPConfigToFactoryOpts_PKCS11_NotActivatedWithoutLibrary(t *testing.T) {
+	t.Parallel()
+
+	mspCfg := MSPConfig{
+		ConfigPath: "/tmp/msp",
+		BCCSP: BCCSPConfig{
+			PKCS11: BCCSPPKCS11Config{
+				Label: "only-label-without-library",
+			},
+		},
+	}
+
+	opts := mspCfg.ToFactoryOpts()
+
+	require.Equal(t, "SW", opts.Default)
+	require.Nil(t, opts.PKCS11)
+}

--- a/tools/fxconfig/internal/config/config.go
+++ b/tools/fxconfig/internal/config/config.go
@@ -11,8 +11,11 @@ package config
 
 import (
 	"cmp"
+	"path/filepath"
 	"slices"
 	"time"
+
+	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
 )
 
 // Config represents the complete fxconfig configuration.
@@ -51,8 +54,45 @@ type LoggingConfig struct {
 // MSPConfig contains MSP (Membership Service Provider) identity configuration.
 // It specifies which organization identity to use for signing transactions.
 type MSPConfig struct {
-	LocalMspID string `mapstructure:"localMspID" yaml:"localMspID,omitempty" desc:"MSP ID of the organization"`
-	ConfigPath string `mapstructure:"configPath" yaml:"configPath,omitempty" desc:"Path to MSP configuration directory"`
+	LocalMspID string      `mapstructure:"localMspID" yaml:"localMspID,omitempty" desc:"MSP ID of the organization"`
+	ConfigPath string      `mapstructure:"configPath" yaml:"configPath,omitempty" desc:"Path to MSP configuration directory"`
+	BCCSP      BCCSPConfig `mapstructure:"bccsp" yaml:"bccsp,omitempty"`
+}
+
+// BCCSPConfig contains BCCSP (crypto provider) settings for MSP instantiation.
+// Defaults to software-based provider with SHA2-256 and file keystore.
+type BCCSPConfig struct {
+	Default string        `mapstructure:"default" yaml:"default,omitempty" default:"SW"`
+	SW      BCCSPSWConfig `mapstructure:"sw" yaml:"sw,omitempty"`
+}
+
+// BCCSPSWConfig contains software provider settings.
+type BCCSPSWConfig struct {
+	Security     int                     `mapstructure:"security" yaml:"security,omitempty" default:"256"`
+	Hash         string                  `mapstructure:"hash" yaml:"hash,omitempty" default:"SHA2"`
+	FileKeyStore BCCSPFileKeyStoreConfig `mapstructure:"fileKeyStore" yaml:"fileKeyStore,omitempty"`
+}
+
+// BCCSPFileKeyStoreConfig contains key store options for the software provider.
+type BCCSPFileKeyStoreConfig struct {
+	KeyStorePath string `mapstructure:"keyStorePath" yaml:"keyStorePath,omitempty"`
+}
+
+// ToFactoryOpts converts fxconfig MSP BCCSP configuration into Fabric factory options.
+// If keyStorePath is not set, it defaults to <msp.configPath>/keystore.
+func (c MSPConfig) ToFactoryOpts() *factory.FactoryOpts {
+	opts := &factory.FactoryOpts{
+		Default: cmp.Or(c.BCCSP.Default, "SW"),
+		SW: &factory.SwOpts{
+			Security: cmp.Or(c.BCCSP.SW.Security, 256),
+			Hash:     cmp.Or(c.BCCSP.SW.Hash, "SHA2"),
+			FileKeystore: &factory.FileKeystoreOpts{
+				KeyStorePath: cmp.Or(c.BCCSP.SW.FileKeyStore.KeyStorePath, filepath.Join(c.ConfigPath, "keystore")),
+			},
+		},
+	}
+
+	return opts
 }
 
 // TLSConfig specifies TLS settings for secure communication.

--- a/tools/fxconfig/internal/config/config.go
+++ b/tools/fxconfig/internal/config/config.go
@@ -55,7 +55,7 @@ type LoggingConfig struct {
 // It specifies which organization identity to use for signing transactions.
 type MSPConfig struct {
 	LocalMspID string      `mapstructure:"localMspID" yaml:"localMspID,omitempty" desc:"MSP ID of the organization"`
-	ConfigPath string      `mapstructure:"configPath" yaml:"configPath,omitempty" desc:"Path to MSP configuration directory"`
+	ConfigPath string      `mapstructure:"configPath" yaml:"configPath,omitempty" desc:"Path to MSP config directory"`
 	BCCSP      BCCSPConfig `mapstructure:"bccsp" yaml:"bccsp,omitempty"`
 }
 

--- a/tools/fxconfig/internal/config/config.go
+++ b/tools/fxconfig/internal/config/config.go
@@ -62,14 +62,14 @@ type MSPConfig struct {
 // BCCSPConfig contains BCCSP (crypto provider) settings for MSP instantiation.
 // Defaults to software-based provider with SHA2-256 and file keystore.
 type BCCSPConfig struct {
-	Default string        `mapstructure:"default" yaml:"default,omitempty" default:"SW"`
+	Default string        `mapstructure:"default" yaml:"default,omitempty"`
 	SW      BCCSPSWConfig `mapstructure:"sw" yaml:"sw,omitempty"`
 }
 
 // BCCSPSWConfig contains software provider settings.
 type BCCSPSWConfig struct {
-	Security     int                     `mapstructure:"security" yaml:"security,omitempty" default:"256"`
-	Hash         string                  `mapstructure:"hash" yaml:"hash,omitempty" default:"SHA2"`
+	Security     int                     `mapstructure:"security" yaml:"security,omitempty"`
+	Hash         string                  `mapstructure:"hash" yaml:"hash,omitempty"`
 	FileKeyStore BCCSPFileKeyStoreConfig `mapstructure:"fileKeyStore" yaml:"fileKeyStore,omitempty"`
 }
 

--- a/tools/fxconfig/internal/config/config.go
+++ b/tools/fxconfig/internal/config/config.go
@@ -61,9 +61,11 @@ type MSPConfig struct {
 
 // BCCSPConfig contains BCCSP (crypto provider) settings for MSP instantiation.
 // Defaults to software-based provider with SHA2-256 and file keystore.
+// To use a PKCS#11 HSM, set PKCS11.Library (requires building with -tags pkcs11).
 type BCCSPConfig struct {
-	Default string        `mapstructure:"default" yaml:"default,omitempty" default:"SW"`
-	SW      BCCSPSWConfig `mapstructure:"sw" yaml:"sw,omitempty"`
+	Default string            `mapstructure:"default" yaml:"default,omitempty" default:"SW"`
+	SW      BCCSPSWConfig     `mapstructure:"sw" yaml:"sw,omitempty"`
+	PKCS11  BCCSPPKCS11Config `mapstructure:"pkcs11" yaml:"pkcs11,omitempty"`
 }
 
 // BCCSPSWConfig contains software provider settings.
@@ -78,8 +80,23 @@ type BCCSPFileKeyStoreConfig struct {
 	KeyStorePath string `mapstructure:"keyStorePath" yaml:"keyStorePath,omitempty"`
 }
 
+// BCCSPPKCS11Config contains PKCS#11 HSM provider settings.
+// When Library is set (and the binary is built with -tags pkcs11), the signer
+// uses the HSM for key material instead of a file-based keystore.
+type BCCSPPKCS11Config struct {
+	Library        string `mapstructure:"library" yaml:"library,omitempty"`
+	Label          string `mapstructure:"label" yaml:"label,omitempty"`
+	Pin            string `mapstructure:"pin" yaml:"pin,omitempty"`
+	Hash           string `mapstructure:"hash" yaml:"hash,omitempty"`
+	Security       int    `mapstructure:"security" yaml:"security,omitempty"`
+	SoftwareVerify bool   `mapstructure:"softwareVerify" yaml:"softwareVerify,omitempty"`
+	Immutable      bool   `mapstructure:"immutable" yaml:"immutable,omitempty"`
+}
+
 // ToFactoryOpts converts fxconfig MSP BCCSP configuration into Fabric factory options.
 // If keyStorePath is not set, it defaults to <msp.configPath>/keystore.
+// If BCCSP.PKCS11.Library is set and the binary is built with -tags pkcs11, the
+// factory is configured for the PKCS#11 provider instead of SW.
 func (c MSPConfig) ToFactoryOpts() *factory.FactoryOpts {
 	opts := &factory.FactoryOpts{
 		Default: cmp.Or(c.BCCSP.Default, "SW"),
@@ -91,6 +108,8 @@ func (c MSPConfig) ToFactoryOpts() *factory.FactoryOpts {
 			},
 		},
 	}
+
+	applyPKCS11Opts(opts, c.BCCSP.PKCS11)
 
 	return opts
 }

--- a/tools/fxconfig/internal/config/config_test.go
+++ b/tools/fxconfig/internal/config/config_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package config
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -195,4 +196,48 @@ func TestConfig_ResolveTLS_ServiceOverrides(t *testing.T) {
 
 	require.Equal(t, []string{"parent-ca.pem"}, cfg.Queries.TLS.RootCertPaths)
 	require.Equal(t, []string{"parent-ca.pem"}, cfg.Notifications.TLS.RootCertPaths)
+}
+
+func TestMSPConfigToFactoryOpts_Defaults(t *testing.T) {
+	t.Parallel()
+
+	mspCfg := MSPConfig{
+		ConfigPath: "/tmp/msp",
+	}
+
+	opts := mspCfg.ToFactoryOpts()
+
+	require.Equal(t, "SW", opts.Default)
+	require.NotNil(t, opts.SW)
+	require.Equal(t, 256, opts.SW.Security)
+	require.Equal(t, "SHA2", opts.SW.Hash)
+	require.NotNil(t, opts.SW.FileKeystore)
+	require.Equal(t, filepath.Join("/tmp/msp", "keystore"), opts.SW.FileKeystore.KeyStorePath)
+}
+
+func TestMSPConfigToFactoryOpts_Overrides(t *testing.T) {
+	t.Parallel()
+
+	mspCfg := MSPConfig{
+		ConfigPath: "/tmp/msp",
+		BCCSP: BCCSPConfig{
+			Default: "SW",
+			SW: BCCSPSWConfig{
+				Security: 384,
+				Hash:     "SHA3",
+				FileKeyStore: BCCSPFileKeyStoreConfig{
+					KeyStorePath: "/custom/keystore",
+				},
+			},
+		},
+	}
+
+	opts := mspCfg.ToFactoryOpts()
+
+	require.Equal(t, "SW", opts.Default)
+	require.NotNil(t, opts.SW)
+	require.Equal(t, 384, opts.SW.Security)
+	require.Equal(t, "SHA3", opts.SW.Hash)
+	require.NotNil(t, opts.SW.FileKeystore)
+	require.Equal(t, "/custom/keystore", opts.SW.FileKeystore.KeyStorePath)
 }

--- a/tools/fxconfig/internal/config/load_test.go
+++ b/tools/fxconfig/internal/config/load_test.go
@@ -9,6 +9,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -68,29 +69,37 @@ func TestLoad_WithConfigFile(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
-	configContent := `
-msp:
-  localMspID: TestMSP
-  configPath: /path/to/msp
-
-orderer:
-  address: orderer.example.com:7050
-  connectionTimeout: 45s
-  tls:
-    rootCerts:
-      - /path/to/ca.pem
-    clientCert: /path/to/cert.pem
-    clientKey: /path/to/key.pem
-    serverNameOverride: orderer.override.com
-
-queries:
-  address: query.example.com:7001
-  connectionTimeout: 60s
-
-notifications:
-  address: notify.example.com:7002
-  connectionTimeout: 90s
-`
+	configContent := strings.Join([]string{
+		"msp:",
+		"  localMspID: TestMSP",
+		"  configPath: /path/to/msp",
+		"  bccsp:",
+		"    default: SW",
+		"    sw:",
+		"      security: 384",
+		"      hash: SHA3",
+		"      fileKeyStore:",
+		"        keyStorePath: /path/to/custom/keystore",
+		"",
+		"orderer:",
+		"  address: orderer.example.com:7050",
+		"  connectionTimeout: 45s",
+		"  tls:",
+		"    rootCerts:",
+		"      - /path/to/ca.pem",
+		"    clientCert: /path/to/cert.pem",
+		"    clientKey: /path/to/key.pem",
+		"    serverNameOverride: orderer.override.com",
+		"",
+		"queries:",
+		"  address: query.example.com:7001",
+		"  connectionTimeout: 60s",
+		"",
+		"notifications:",
+		"  address: notify.example.com:7002",
+		"  connectionTimeout: 90s",
+		"",
+	}, "\n")
 	err := os.WriteFile(configPath, []byte(configContent), 0o600)
 	require.NoError(t, err)
 
@@ -101,6 +110,10 @@ notifications:
 
 	assert.Equal(t, "TestMSP", cfg.MSP.LocalMspID)
 	assert.Equal(t, "/path/to/msp", cfg.MSP.ConfigPath)
+	assert.Equal(t, "SW", cfg.MSP.BCCSP.Default)
+	assert.Equal(t, 384, cfg.MSP.BCCSP.SW.Security)
+	assert.Equal(t, "SHA3", cfg.MSP.BCCSP.SW.Hash)
+	assert.Equal(t, "/path/to/custom/keystore", cfg.MSP.BCCSP.SW.FileKeyStore.KeyStorePath)
 
 	assert.Equal(t, "orderer.example.com:7050", cfg.Orderer.Address)
 	assert.Equal(t, 45*time.Second, cfg.Orderer.ConnectionTimeout)

--- a/tools/fxconfig/internal/config/load_test.go
+++ b/tools/fxconfig/internal/config/load_test.go
@@ -9,7 +9,6 @@ package config
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -69,37 +68,36 @@ func TestLoad_WithConfigFile(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
-	configContent := strings.Join([]string{
-		"msp:",
-		"  localMspID: TestMSP",
-		"  configPath: /path/to/msp",
-		"  bccsp:",
-		"    default: SW",
-		"    sw:",
-		"      security: 384",
-		"      hash: SHA3",
-		"      fileKeyStore:",
-		"        keyStorePath: /path/to/custom/keystore",
-		"",
-		"orderer:",
-		"  address: orderer.example.com:7050",
-		"  connectionTimeout: 45s",
-		"  tls:",
-		"    rootCerts:",
-		"      - /path/to/ca.pem",
-		"    clientCert: /path/to/cert.pem",
-		"    clientKey: /path/to/key.pem",
-		"    serverNameOverride: orderer.override.com",
-		"",
-		"queries:",
-		"  address: query.example.com:7001",
-		"  connectionTimeout: 60s",
-		"",
-		"notifications:",
-		"  address: notify.example.com:7002",
-		"  connectionTimeout: 90s",
-		"",
-	}, "\n")
+	configContent := `
+msp:
+  localMspID: TestMSP
+  configPath: /path/to/msp
+  bccsp:
+    default: SW
+    sw:
+      security: 384
+      hash: SHA3
+      fileKeyStore:
+        keyStorePath: /path/to/custom/keystore
+
+orderer:
+  address: orderer.example.com:7050
+  connectionTimeout: 45s
+  tls:
+    rootCerts:
+      - /path/to/ca.pem
+    clientCert: /path/to/cert.pem
+    clientKey: /path/to/key.pem
+    serverNameOverride: orderer.override.com
+
+queries:
+  address: query.example.com:7001
+  connectionTimeout: 60s
+
+notifications:
+  address: notify.example.com:7002
+  connectionTimeout: 90s
+`
 	err := os.WriteFile(configPath, []byte(configContent), 0o600)
 	require.NoError(t, err)
 

--- a/tools/fxconfig/internal/msp/signer.go
+++ b/tools/fxconfig/internal/msp/signer.go
@@ -9,9 +9,8 @@ package msp
 
 import (
 	"fmt"
-	"path"
 
-	"github.com/hyperledger/fabric-lib-go/bccsp/sw"
+	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
 
 	"github.com/hyperledger/fabric-x-common/msp"
 	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/config"
@@ -38,20 +37,14 @@ func GetSignerIdentityFromMSP(cfg config.MSPConfig) (msp.SigningIdentity, error)
 //
 //nolint:ireturn
 func setupMSP(mspCfg config.MSPConfig) (msp.MSP, error) {
-	conf, err := msp.GetLocalMspConfig(mspCfg.ConfigPath, nil, mspCfg.LocalMspID)
+	bccspOpts := mspCfg.ToFactoryOpts()
+
+	conf, err := msp.GetLocalMspConfig(mspCfg.ConfigPath, bccspOpts, mspCfg.LocalMspID)
 	if err != nil {
 		return nil, fmt.Errorf("error getting local msp config from %v: %w", mspCfg.ConfigPath, err)
 	}
 
-	// TODO: get proper BCCSP connfiguration via config
-
-	dir := path.Join(mspCfg.ConfigPath, "keystore")
-	ks, err := sw.NewFileBasedKeyStore(nil, dir, true)
-	if err != nil {
-		return nil, err
-	}
-
-	cp, err := sw.NewDefaultSecurityLevelWithKeystore(ks)
+	cp, err := factory.GetBCCSPFromOpts(bccspOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/fxconfig/internal/msp/signer.go
+++ b/tools/fxconfig/internal/msp/signer.go
@@ -33,7 +33,7 @@ func GetSignerIdentityFromMSP(cfg config.MSPConfig) (msp.SigningIdentity, error)
 	return sid, nil
 }
 
-// setupMSP creates an MSP instance with file-based BCCSP keystore from the given configuration.
+// setupMSP creates an MSP instance using the BCCSP crypto provider derived from the given configuration.
 //
 //nolint:ireturn
 func setupMSP(mspCfg config.MSPConfig) (msp.MSP, error) {
@@ -46,7 +46,7 @@ func setupMSP(mspCfg config.MSPConfig) (msp.MSP, error) {
 
 	cp, err := factory.GetBCCSPFromOpts(bccspOpts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error creating bccsp from opts: %w", err)
 	}
 
 	mspOpts := &msp.BCCSPNewOpts{

--- a/tools/fxconfig/internal/msp/signer_test.go
+++ b/tools/fxconfig/internal/msp/signer_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package msp
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -80,6 +81,31 @@ func TestGetSignerIdentityFromMSP(t *testing.T) {
 		sig, err := sid.Sign([]byte("test message"))
 		require.NoError(t, err)
 		require.NotEmpty(t, sig)
+	})
+
+	t.Run("success with explicit bccsp config", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := config.MSPConfig{
+			LocalMspID: "Org1MSP",
+			ConfigPath: testdataMSPDir(),
+			BCCSP: config.BCCSPConfig{
+				Default: "SW",
+				SW: config.BCCSPSWConfig{
+					Security: 256,
+					Hash:     "SHA2",
+					FileKeyStore: config.BCCSPFileKeyStoreConfig{
+						KeyStorePath: filepath.Join(testdataMSPDir(), "keystore"),
+					},
+				},
+			},
+		}
+
+		sid, err := GetSignerIdentityFromMSP(cfg)
+
+		require.NoError(t, err)
+		require.NotNil(t, sid)
+		require.Equal(t, "Org1MSP", sid.GetMSPIdentifier())
 	})
 
 	t.Run("signer can serialize identity", func(t *testing.T) {

--- a/tools/fxconfig/internal/msp/signer_test.go
+++ b/tools/fxconfig/internal/msp/signer_test.go
@@ -108,6 +108,25 @@ func TestGetSignerIdentityFromMSP(t *testing.T) {
 		require.Equal(t, "Org1MSP", sid.GetMSPIdentifier())
 	})
 
+	t.Run("success with default bccsp config", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := config.MSPConfig{
+			LocalMspID: "Org1MSP",
+			ConfigPath: testdataMSPDir(),
+		}
+
+		sid, err := GetSignerIdentityFromMSP(cfg)
+
+		require.NoError(t, err)
+		require.NotNil(t, sid)
+		require.Equal(t, "Org1MSP", sid.GetMSPIdentifier())
+
+		sig, err := sid.Sign([]byte("test with defaults"))
+		require.NoError(t, err)
+		require.NotEmpty(t, sig)
+	})
+
 	t.Run("signer can serialize identity", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
<!--
Copyright IBM Corp. All Rights Reserved.

SPDX-License-Identifier: Apache-2.0

DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST.

If this PR introduces a breaking change that affects compatibility with other components:
- The PR title must begin with the prefix [BREAKING].
- "Breaking change" must be included in the list below.
- Relevant stakeholders must be notified before or immediately after the PR is merged.
-->
#### Type of change

<!--- What type of change? Pick one or more options and delete the others. -->
- New feature
- Improvement (improvement to code, performance, etc)
- Test update
- Documentation update


#### Description

<!--- Describe your changes in detail, including motivation. -->
This PR adds configurable BCCSP support to fxconfig for MSP signer setup.

Instead of hardcoding software BCCSP defaults in the signer path, the MSP config now supports a bccsp section and uses it to instantiate the crypto provider correctly.
The implementation also keeps sensible defaults (SW, SHA2, 256, keystore under MSP path) when values are not provided.

Included in this PR:

- BCCSP config structs under msp config
- Conversion logic to Fabric FactoryOpts
- Signer update to use config-driven BCCSP instantiation
- Tests for defaults, overrides, and config loading
- Docs update with config examples

#### Additional details (Optional)

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

- Added new config models under `msp.bccsp`:
  - `default`
  - `sw.security`
  - `sw.hash`
  - `sw.fileKeyStore.keyStorePath`
- Added conversion helper from fxconfig config model to Fabric `factory.FactoryOpts`
- Updated signer setup to:
  - pass BCCSP opts to `GetLocalMspConfig`
  - instantiate provider via `factory.GetBCCSPFromOpts`
- Added tests for:
  - default BCCSP mapping
  - override mapping
  - config file loading of BCCSP settings
  - signer initialization with explicit BCCSP config
- Updated docs with example `msp.bccsp` configuration

Testing performed:

- `go test ./tools/fxconfig/internal/config -run "TestMSPConfigToFactoryOpts_Defaults|TestMSPConfigToFactoryOpts_Overrides|TestLoad_WithConfigFile"`
- `go test ./tools/fxconfig/internal/msp -run "TestGetSignerIdentityFromMSP"`
- `go build ./tools/fxconfig`

#### Related issues

<!--- Include a link to any associated Github issue -->
Related to #60 
