### PR TITLE
feat(fxconfig): add chaincode rwset adapter scaffold

### DIFF
--- a/tools/fxconfig/internal/transaction/chaincode_adapter.go
+++ b/tools/fxconfig/internal/transaction/chaincode_adapter.go
@@ -1,0 +1,76 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package transaction
+
+import (
+	"fmt"
+
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+)
+
+// ChaincodeWrite represents a chaincode-style write operation.
+type ChaincodeWrite struct {
+	Key     string
+	Value   []byte
+	Version *uint64
+}
+
+// ChaincodeNamespaceRWSet represents chaincode read-write output for one namespace.
+type ChaincodeNamespaceRWSet struct {
+	Namespace string
+	Version   uint64
+	Writes    []ChaincodeWrite
+}
+
+// CreateTxNamespaceFromChaincodeRWSet converts one chaincode namespace rwset into a Fabric-X TxNamespace.
+func CreateTxNamespaceFromChaincodeRWSet(rwset ChaincodeNamespaceRWSet) (*applicationpb.TxNamespace, error) {
+	if rwset.Namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+
+	ns := &applicationpb.TxNamespace{
+		NsId:       rwset.Namespace,
+		NsVersion:  rwset.Version,
+		ReadWrites: make([]*applicationpb.ReadWrite, 0, len(rwset.Writes)),
+	}
+
+	for _, w := range rwset.Writes {
+		if w.Key == "" {
+			return nil, fmt.Errorf("write key is required")
+		}
+
+		rw := &applicationpb.ReadWrite{
+			Key:   []byte(w.Key),
+			Value: w.Value,
+		}
+		if w.Version != nil {
+			rw.Version = applicationpb.NewVersion(*w.Version)
+		}
+
+		ns.ReadWrites = append(ns.ReadWrites, rw)
+	}
+
+	return ns, nil
+}
+
+// CreateTxFromChaincodeRWSets converts multiple chaincode namespace rwsets into a Fabric-X transaction.
+func CreateTxFromChaincodeRWSets(rwsets []ChaincodeNamespaceRWSet) (*applicationpb.Tx, error) {
+	if len(rwsets) == 0 {
+		return nil, fmt.Errorf("at least one namespace rwset is required")
+	}
+
+	namespaces := make([]*applicationpb.TxNamespace, 0, len(rwsets))
+	for _, rwset := range rwsets {
+		ns, err := CreateTxNamespaceFromChaincodeRWSet(rwset)
+		if err != nil {
+			return nil, err
+		}
+		namespaces = append(namespaces, ns)
+	}
+
+	return &applicationpb.Tx{Namespaces: namespaces}, nil
+}

--- a/tools/fxconfig/internal/transaction/chaincode_adapter_test.go
+++ b/tools/fxconfig/internal/transaction/chaincode_adapter_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package transaction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateTxNamespaceFromChaincodeRWSet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("maps chaincode rwset into tx namespace", func(t *testing.T) {
+		t.Parallel()
+
+		v := uint64(3)
+		rwset := ChaincodeNamespaceRWSet{
+			Namespace: "asset",
+			Version:   2,
+			Writes: []ChaincodeWrite{
+				{Key: "a1", Value: []byte("v1")},
+				{Key: "a2", Value: []byte("v2"), Version: &v},
+			},
+		}
+
+		ns, err := CreateTxNamespaceFromChaincodeRWSet(rwset)
+		require.NoError(t, err)
+		require.Equal(t, "asset", ns.NsId)
+		require.Equal(t, uint64(2), ns.NsVersion)
+		require.Len(t, ns.ReadWrites, 2)
+		require.Equal(t, []byte("a1"), ns.ReadWrites[0].Key)
+		require.Equal(t, []byte("v1"), ns.ReadWrites[0].Value)
+		require.Nil(t, ns.ReadWrites[0].Version)
+		require.NotNil(t, ns.ReadWrites[1].Version)
+		require.Equal(t, uint64(3), *ns.ReadWrites[1].Version)
+	})
+
+	t.Run("fails on empty namespace", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := CreateTxNamespaceFromChaincodeRWSet(ChaincodeNamespaceRWSet{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "namespace is required")
+	})
+
+	t.Run("fails on empty key", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := CreateTxNamespaceFromChaincodeRWSet(ChaincodeNamespaceRWSet{
+			Namespace: "asset",
+			Writes: []ChaincodeWrite{
+				{Key: "", Value: []byte("v")},
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "write key is required")
+	})
+}
+
+func TestCreateTxFromChaincodeRWSets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("maps multiple namespaces", func(t *testing.T) {
+		t.Parallel()
+
+		tx, err := CreateTxFromChaincodeRWSets([]ChaincodeNamespaceRWSet{
+			{Namespace: "asset", Writes: []ChaincodeWrite{{Key: "k1", Value: []byte("v1")}}},
+			{Namespace: "payment", Writes: []ChaincodeWrite{{Key: "k2", Value: []byte("v2")}}},
+		})
+		require.NoError(t, err)
+		require.Len(t, tx.Namespaces, 2)
+		require.Equal(t, "asset", tx.Namespaces[0].NsId)
+		require.Equal(t, "payment", tx.Namespaces[1].NsId)
+	})
+
+	t.Run("fails on empty list", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := CreateTxFromChaincodeRWSets(nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "at least one namespace rwset is required")
+	})
+}


### PR DESCRIPTION
<!--
Copyright IBM Corp. All Rights Reserved.

SPDX-License-Identifier: Apache-2.0

DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST.

If this PR introduces a breaking change that affects compatibility with other components:
- The PR title must begin with the prefix [BREAKING].
- "Breaking change" must be included in the list below.
- Relevant stakeholders must be notified before or immediately after the PR is merged.
-->
#### Type of change

<!--- What type of change? Pick one or more options and delete the others. -->
- New feature
- Improvement (improvement to code, performance, etc)
- Test update

#### Description

<!--- Describe your changes in detail, including motivation. -->
This PR adds a small adapter in fxconfig to convert chaincode-style RW sets into Fabric-X transaction namespaces.

Scope:

- converted one namespace RW set into TxNamespace
- builded a tx from multiple namespace RW sets
- basic validation for required fields (namespace, key)
- This is groundwork for chaincode migration exploration, not a full compatibility implementation.

#### Additional details (Optional)

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->
Covered cases:

- happy path mapping
- empty namespace
- empty key
- empty rwset list

Tested with:

- go test ./tools/fxconfig/internal/transaction
- go build ./tools/fxconfig

#### Related issues

<!--- Include a link to any associated Github issue -->
