### PR TITLE
samples/tokens: make CORS and bind address configurable

### DIFF
--- a/samples/tokens/README.md
+++ b/samples/tokens/README.md
@@ -251,6 +251,29 @@ They also communicate over P2P websockets as shown below:
 
 We can use the Swagger API on [http://localhost:8080](http://localhost:8080) or call the API directly via `curl`.
 
+### CORS and bind address configuration
+
+The sample services support configurable CORS and bind address behavior:
+
+- `BIND_ADDR`: host interface to bind the REST API service (default: `0.0.0.0`).
+- `ALLOWED_ORIGINS`: comma-separated CORS allow-list (example: `http://localhost:8080,http://127.0.0.1:8080`).
+  - Default allows Swagger UI local origins: `http://localhost:8080` and `http://127.0.0.1:8080`.
+  - Set to `*` to allow any origin.
+- `ALLOW_AUTH_HEADER`: set to `true` to include `Authorization` in CORS allowed headers.
+
+Examples:
+
+```bash
+# Restrict service to localhost only
+export BIND_ADDR=127.0.0.1
+
+# Explicit CORS allow-list
+export ALLOWED_ORIGINS=http://localhost:8080
+
+# Include Authorization in CORS headers
+export ALLOW_AUTH_HEADER=true
+```
+
 Now let's issue and transfer some tokens!
 
 ## Example: Issue tokens

--- a/samples/tokens/common/fsc.go
+++ b/samples/tokens/common/fsc.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/hyperledger-labs/fabric-smart-client/node"
 )
@@ -33,18 +34,92 @@ func StartFSC(confPath, datadir string) (*node.Node, error) {
 	return fsc, nil
 }
 
-// WithAnyCORS adds permissive CORS headers to all responses
-func WithAnyCORS(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Allow all origins
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+// BindAddress returns the host used by HTTP services.
+// By default we keep 0.0.0.0 for docker/native compatibility.
+func BindAddress() string {
+	if bindAddr := strings.TrimSpace(os.Getenv("BIND_ADDR")); bindAddr != "" {
+		return bindAddr
+	}
+	return "0.0.0.0"
+}
 
-		// Handle preflight requests
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(http.StatusNoContent)
-			return
+func allowedOriginsFromEnv() map[string]struct{} {
+	allowedOrigins := map[string]struct{}{}
+
+	// Safe defaults that still allow Swagger UI at localhost:8080 out of the box.
+	for _, origin := range []string{"http://localhost:8080", "http://127.0.0.1:8080"} {
+		allowedOrigins[origin] = struct{}{}
+	}
+
+	raw := strings.TrimSpace(os.Getenv("ALLOWED_ORIGINS"))
+	if raw == "" {
+		return allowedOrigins
+	}
+
+	custom := map[string]struct{}{}
+	for _, item := range strings.Split(raw, ",") {
+		origin := strings.TrimSpace(item)
+		if origin == "" {
+			continue
+		}
+		custom[origin] = struct{}{}
+	}
+
+	if len(custom) == 0 {
+		return allowedOrigins
+	}
+
+	return custom
+}
+
+func allowAuthHeader() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("ALLOW_AUTH_HEADER")))
+	return v == "1" || v == "true" || v == "yes"
+}
+
+// WithCORS adds configurable CORS headers.
+func WithCORS(next http.Handler) http.Handler {
+	allowedOrigins := allowedOriginsFromEnv()
+	allowAnyOrigin := false
+	if _, ok := allowedOrigins["*"]; ok {
+		allowAnyOrigin = true
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := strings.TrimSpace(r.Header.Get("Origin"))
+		if origin != "" {
+			isAllowed := allowAnyOrigin
+			if !isAllowed {
+				_, isAllowed = allowedOrigins[origin]
+			}
+
+			if !isAllowed {
+				if r.Method == http.MethodOptions {
+					http.Error(w, "origin not allowed", http.StatusForbidden)
+					return
+				}
+				http.Error(w, "origin not allowed", http.StatusForbidden)
+				return
+			}
+
+			if allowAnyOrigin {
+				w.Header().Set("Access-Control-Allow-Origin", "*")
+			} else {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set("Vary", "Origin")
+			}
+
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+			if allowAuthHeader() {
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			} else {
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+			}
+
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
 		}
 
 		next.ServeHTTP(w, r)

--- a/samples/tokens/common/fsc_test.go
+++ b/samples/tokens/common/fsc_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBindAddress_DefaultAndOverride(t *testing.T) {
+	t.Setenv("BIND_ADDR", "")
+	require.Equal(t, "0.0.0.0", BindAddress())
+
+	t.Setenv("BIND_ADDR", "127.0.0.1")
+	require.Equal(t, "127.0.0.1", BindAddress())
+}
+
+func TestWithCORS_DefaultAllowsSwaggerLocalhost(t *testing.T) {
+	t.Setenv("ALLOWED_ORIGINS", "")
+	t.Setenv("ALLOW_AUTH_HEADER", "")
+
+	h := WithCORS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	req.Header.Set("Origin", "http://localhost:8080")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	require.Equal(t, http.StatusNoContent, rw.Code)
+	require.Equal(t, "http://localhost:8080", rw.Header().Get("Access-Control-Allow-Origin"))
+	require.Equal(t, "Content-Type", rw.Header().Get("Access-Control-Allow-Headers"))
+}
+
+func TestWithCORS_DefaultRejectsUnknownOrigin(t *testing.T) {
+	t.Setenv("ALLOWED_ORIGINS", "")
+
+	h := WithCORS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	req.Header.Set("Origin", "http://evil.example")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	require.Equal(t, http.StatusForbidden, rw.Code)
+}
+
+func TestWithCORS_CustomAllowedOrigins(t *testing.T) {
+	t.Setenv("ALLOWED_ORIGINS", "http://example.com, http://localhost:8080")
+
+	h := WithCORS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	req.Header.Set("Origin", "http://example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	require.Equal(t, http.StatusNoContent, rw.Code)
+	require.Equal(t, "http://example.com", rw.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestWithCORS_AllowAnyOrigin(t *testing.T) {
+	t.Setenv("ALLOWED_ORIGINS", "*")
+
+	h := WithCORS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	req.Header.Set("Origin", "http://evil.example")
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	require.Equal(t, http.StatusNoContent, rw.Code)
+	require.Equal(t, "*", rw.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestWithCORS_AllowAuthorizationHeader(t *testing.T) {
+	t.Setenv("ALLOWED_ORIGINS", "http://localhost:8080")
+	t.Setenv("ALLOW_AUTH_HEADER", "true")
+
+	h := WithCORS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	req.Header.Set("Origin", "http://localhost:8080")
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+
+	require.Equal(t, http.StatusNoContent, rw.Code)
+	require.Equal(t, "Content-Type, Authorization", rw.Header().Get("Access-Control-Allow-Headers"))
+}

--- a/samples/tokens/endorser/main.go
+++ b/samples/tokens/endorser/main.go
@@ -38,10 +38,10 @@ func main() {
 
 	// Simple web server
 	sh := routes.NewStrictHandler(routes.NewServer(service.NewFSC(fsc)), []routes.StrictMiddlewareFunc{})
-	h := common.WithAnyCORS(routes.HandlerFromMux(sh, http.NewServeMux()))
+	h := common.WithCORS(routes.HandlerFromMux(sh, http.NewServeMux()))
 	s := &http.Server{
 		Handler: h,
-		Addr:    net.JoinHostPort("0.0.0.0", *port),
+		Addr:    net.JoinHostPort(common.BindAddress(), *port),
 	}
 	go s.ListenAndServe()
 

--- a/samples/tokens/issuer/main.go
+++ b/samples/tokens/issuer/main.go
@@ -47,10 +47,10 @@ func main() {
 
 	// Simple web server
 	sh := routes.NewStrictHandler(routes.NewServer(service.NewFSC(fsc)), []routes.StrictMiddlewareFunc{})
-	h := common.WithAnyCORS(routes.HandlerFromMux(sh, http.NewServeMux()))
+	h := common.WithCORS(routes.HandlerFromMux(sh, http.NewServeMux()))
 	s := &http.Server{
 		Handler: h,
-		Addr:    net.JoinHostPort("0.0.0.0", *port),
+		Addr:    net.JoinHostPort(common.BindAddress(), *port),
 	}
 	go s.ListenAndServe()
 

--- a/samples/tokens/owner/main.go
+++ b/samples/tokens/owner/main.go
@@ -47,10 +47,10 @@ func main() {
 
 	// Simple web server
 	sh := routes.NewStrictHandler(routes.NewServer(service.NewFSC(fsc)), []routes.StrictMiddlewareFunc{})
-	h := common.WithAnyCORS(routes.HandlerFromMux(sh, http.NewServeMux()))
+	h := common.WithCORS(routes.HandlerFromMux(sh, http.NewServeMux()))
 	s := &http.Server{
 		Handler: h,
-		Addr:    net.JoinHostPort("0.0.0.0", *port),
+		Addr:    net.JoinHostPort(common.BindAddress(), *port),
 	}
 	go s.ListenAndServe()
 

--- a/samples/tokens/tests/check_cors_default.sh
+++ b/samples/tokens/tests/check_cors_default.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST=${1:-localhost:9300}
+URL="http://${HOST}/endorser/init"
+
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X OPTIONS "$URL" \
+  -H "Origin: http://evil.example" \
+  -H "Access-Control-Request-Method: POST" || true)
+
+if [ "$STATUS" == "403" ]; then
+  echo "PASS: preflight rejected (403)"
+  exit 0
+else
+  echo "FAIL: preflight returned $STATUS"
+  exit 2
+fi


### PR DESCRIPTION
Made samples/tokens safer and configurable by replacing permissive CORS with env-driven allow-list CORS, adding configurable bind address, updating owner/issuer/endorser to use it, adding CORS/bind tests plus a default CORS check script, and documenting the new security settings in the sample README.