### PR TITLE
 feat(samples/tokens): make CORS and bind address configurable

### DIFF
--- a/samples/tokens/README.md
+++ b/samples/tokens/README.md
@@ -33,6 +33,9 @@ The **Token SDK Sample** demonstrates how to:
 - [Interacting with the Application](#interacting-with-the-application)
 - [Example: Issue tokens](#example-issue-tokens)
 - [Example: Transfer tokens](#example-transfer-tokens)
+- [Security Configuration](#security-configuration)
+  - [CORS Configuration](#cors-configuration)
+  - [Network Binding](#network-binding)
 - [Teardown and cleanup](#teardown-and-cleanup)
 - [Development](#development)
 - [Debug mode](#debug-mode)
@@ -283,6 +286,38 @@ curl http://localhost:9500/owner/accounts/alice/transfer -d '{
 
 curl -X GET http://localhost:9600/owner/accounts/dan/transactions | jq
 curl -X GET http://localhost:9500/owner/accounts/alice/transactions | jq
+```
+
+## Security Configuration
+
+The sample includes configurable security settings for CORS and network binding. By default, the sample works out of the box with Swagger UI for local development.
+
+### CORS Configuration
+
+Control which origins can make cross-origin requests to the API:
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `ALLOWED_ORIGINS` | `http://localhost:8080,http://127.0.0.1:8080,http://localhost:3000,http://127.0.0.1:3000` | Comma-separated list of allowed origins. Set to `*` to allow all origins (not recommended for production). |
+| `ALLOW_AUTH_HEADER` | `false` | Set to `true` to include `Authorization` in CORS allowed headers. |
+
+Example for production:
+```shell
+export ALLOWED_ORIGINS="https://your-frontend.example.com"
+export ALLOW_AUTH_HEADER=true
+```
+
+### Network Binding
+
+Control which network interface the services bind to:
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `BIND_ADDRESS` | `0.0.0.0` | The address to bind to. Use `127.0.0.1` for local-only access. |
+
+The default `0.0.0.0` allows the sample to work in both Docker and native configurations. For local-only development:
+```shell
+export BIND_ADDRESS=127.0.0.1
 ```
 
 ## Teardown and cleanup

--- a/samples/tokens/common/fsc.go
+++ b/samples/tokens/common/fsc.go
@@ -10,9 +10,20 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/hyperledger-labs/fabric-smart-client/node"
 )
+
+// Default allowed origins for CORS - supports Swagger UI on common localhost ports.
+// Override with ALLOWED_ORIGINS environment variable (comma-separated list).
+// Set ALLOWED_ORIGINS=* to allow all origins (not recommended for production).
+var defaultAllowedOrigins = []string{
+	"http://localhost:8080",
+	"http://127.0.0.1:8080",
+	"http://localhost:3000",
+	"http://127.0.0.1:3000",
+}
 
 // StartFSC starts a new node.
 func StartFSC(confPath, datadir string) (*node.Node, error) {
@@ -33,13 +44,84 @@ func StartFSC(confPath, datadir string) (*node.Node, error) {
 	return fsc, nil
 }
 
-// WithAnyCORS adds permissive CORS headers to all responses
-func WithAnyCORS(next http.Handler) http.Handler {
+// GetBindAddress returns the address to bind to.
+// Defaults to 0.0.0.0 for Docker compatibility, but can be overridden
+// via BIND_ADDRESS environment variable (e.g., "127.0.0.1" for local-only).
+func GetBindAddress() string {
+	if addr := os.Getenv("BIND_ADDRESS"); addr != "" {
+		return addr
+	}
+	return "0.0.0.0"
+}
+
+// getAllowedOrigins returns the list of allowed CORS origins.
+// Uses ALLOWED_ORIGINS env var if set, otherwise returns defaults.
+func getAllowedOrigins() ([]string, bool) {
+	if env := os.Getenv("ALLOWED_ORIGINS"); env != "" {
+		if env == "*" {
+			return nil, true // allow all
+		}
+		origins := strings.Split(env, ",")
+		for i := range origins {
+			origins[i] = strings.TrimSpace(origins[i])
+		}
+		return origins, false
+	}
+	return defaultAllowedOrigins, false
+}
+
+// isOriginAllowed checks if the given origin is in the allowed list.
+func isOriginAllowed(origin string, allowedOrigins []string, allowAll bool) bool {
+	if allowAll {
+		return true
+	}
+	for _, allowed := range allowedOrigins {
+		if origin == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+// WithCORS adds configurable CORS headers to responses.
+// By default, allows requests from common localhost origins (for Swagger UI).
+// Configure via environment variables:
+//   - ALLOWED_ORIGINS: comma-separated list of allowed origins, or "*" for all
+//   - ALLOW_AUTH_HEADER: set to "true" to include Authorization in allowed headers
+func WithCORS(next http.Handler) http.Handler {
+	allowedOrigins, allowAll := getAllowedOrigins()
+	allowAuthHeader := os.Getenv("ALLOW_AUTH_HEADER") == "true"
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Allow all origins
-		w.Header().Set("Access-Control-Allow-Origin", "*")
+		origin := r.Header.Get("Origin")
+
+		// No Origin header means same-origin request, allow it
+		if origin == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if !isOriginAllowed(origin, allowedOrigins, allowAll) {
+			// Reject cross-origin request from unknown origin
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			// For non-preflight requests, proceed but don't set CORS headers
+			// Browser will block the response
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Set CORS headers for allowed origins
+		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+
+		allowedHeaders := "Content-Type"
+		if allowAuthHeader {
+			allowedHeaders += ", Authorization"
+		}
+		w.Header().Set("Access-Control-Allow-Headers", allowedHeaders)
 
 		// Handle preflight requests
 		if r.Method == http.MethodOptions {

--- a/samples/tokens/endorser/main.go
+++ b/samples/tokens/endorser/main.go
@@ -38,10 +38,10 @@ func main() {
 
 	// Simple web server
 	sh := routes.NewStrictHandler(routes.NewServer(service.NewFSC(fsc)), []routes.StrictMiddlewareFunc{})
-	h := common.WithAnyCORS(routes.HandlerFromMux(sh, http.NewServeMux()))
+	h := common.WithCORS(routes.HandlerFromMux(sh, http.NewServeMux()))
 	s := &http.Server{
 		Handler: h,
-		Addr:    net.JoinHostPort("0.0.0.0", *port),
+		Addr:    net.JoinHostPort(common.GetBindAddress(), *port),
 	}
 	go s.ListenAndServe()
 

--- a/samples/tokens/issuer/main.go
+++ b/samples/tokens/issuer/main.go
@@ -47,10 +47,10 @@ func main() {
 
 	// Simple web server
 	sh := routes.NewStrictHandler(routes.NewServer(service.NewFSC(fsc)), []routes.StrictMiddlewareFunc{})
-	h := common.WithAnyCORS(routes.HandlerFromMux(sh, http.NewServeMux()))
+	h := common.WithCORS(routes.HandlerFromMux(sh, http.NewServeMux()))
 	s := &http.Server{
 		Handler: h,
-		Addr:    net.JoinHostPort("0.0.0.0", *port),
+		Addr:    net.JoinHostPort(common.GetBindAddress(), *port),
 	}
 	go s.ListenAndServe()
 

--- a/samples/tokens/owner/main.go
+++ b/samples/tokens/owner/main.go
@@ -47,10 +47,10 @@ func main() {
 
 	// Simple web server
 	sh := routes.NewStrictHandler(routes.NewServer(service.NewFSC(fsc)), []routes.StrictMiddlewareFunc{})
-	h := common.WithAnyCORS(routes.HandlerFromMux(sh, http.NewServeMux()))
+	h := common.WithCORS(routes.HandlerFromMux(sh, http.NewServeMux()))
 	s := &http.Server{
 		Handler: h,
-		Addr:    net.JoinHostPort("0.0.0.0", *port),
+		Addr:    net.JoinHostPort(common.GetBindAddress(), *port),
 	}
 	go s.ListenAndServe()
 


### PR DESCRIPTION
<!--
Copyright IBM Corp. All Rights Reserved.

SPDX-License-Identifier: Apache-2.0

DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST.

If this PR introduces a breaking change that affects compatibility with other components:
- The PR title must begin with the prefix [BREAKING].
- "Breaking change" must be included in the list below.
- Relevant stakeholders must be notified before or immediately after the PR is merged.
-->
Closes hyperledger/fabric-x-samples#7 
#### Type of change

<!--- What type of change? Pick one or more options and delete the others. -->
- New feature
- Improvement (improvement to code, performance, etc)
- Documentation update
- security improvement

### Description
 Makes CORS and network binding configurable in the tokens sample 
while maintaining out-of-the-box functionality with Swagger UI.
 
 #### Changes
 
 - Replace permissive `WithAnyCORS` middleware with configurable 
`WithCORS` that:
   - Defaults to allowing common localhost origins (8080, 3000) for 
Swagger UI compatibility
   - Supports `ALLOWED_ORIGINS` env var for custom origins 
(comma-separated, or `*` for all)
   - Supports `ALLOW_AUTH_HEADER=true` to opt-in to exposing 
Authorization header
 - Add `GetBindAddress()` helper with `BIND_ADDRESS` env var 
(defaults to `0.0.0.0` for Docker compatibility)
 - Update owner, issuer, and endorser services to use the new 
configurable middleware
 - Document configuration options in README
 
 ## Security Improvements
 
 | Before | After |
 |--------|-------|
 | CORS allowed all origins (`*`) | CORS restricted to localhost by 
default |
 | Authorization header always exposed | Authorization header opt-in
 only |
 | Hardcoded `0.0.0.0` binding | Configurable via `BIND_ADDRESS` |
 
 ## Backward Compatibility
 
 ✅ Sample works out of the box without any configuration changes  
 ✅ Swagger UI at localhost:8080 works by default  
 ✅ Works in both Docker and native configurations  
 
 ## Configuration
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ALLOWED_ORIGINS` | `http://localhost:8080,...` | Comma-separated
 allowed origins, or `*` |
 | `ALLOW_AUTH_HEADER` | `false` | Set `true` to include 
Authorization in CORS |
 | `BIND_ADDRESS` | `0.0.0.0` | Network interface to bind to |

<!--- Describe your changes in detail, including motivation. -->


