### PR TITLE
feat(samples/tokens): make CORS and bind address configurable

### DIFF
--- a/samples/tokens/README.md
+++ b/samples/tokens/README.md
@@ -212,6 +212,26 @@ curl -X POST http://localhost:9300/endorser/init
 
 Now open <http://localhost:8080> in your browser to see the other API endpoints, or scroll down to follow some `curl` commands.
 
+### Security-related runtime defaults
+
+The services support environment variables for safer defaults while remaining docker-friendly:
+
+- `BIND_ADDRESS`: host/interface for API binding. Default: `127.0.0.1`.
+- `ALLOWED_ORIGINS`: comma-separated allowed CORS origins. Default: empty (cross-origin rejected).
+- `ALLOW_AUTH_HEADER`: set to `true` to include `Authorization` in CORS allow headers. Default: disabled.
+
+In docker compose, these are set so Swagger can call the sample APIs out of the box:
+
+- `BIND_ADDRESS=0.0.0.0`
+- `ALLOWED_ORIGINS=http://localhost:8080,http://127.0.0.1:8080`
+- `ALLOW_AUTH_HEADER=true`
+
+You can verify the secure default behavior (unknown origins rejected) with:
+
+```bash
+./tests/check_cors_default.sh
+```
+
 ## Option 3: Fabric v3
 
 Run the same application against a classic Fabric v3 network.

--- a/samples/tokens/common/fsc.go
+++ b/samples/tokens/common/fsc.go
@@ -8,8 +8,10 @@ package common
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/hyperledger-labs/fabric-smart-client/node"
 )
@@ -33,15 +35,45 @@ func StartFSC(confPath, datadir string) (*node.Node, error) {
 	return fsc, nil
 }
 
-// WithAnyCORS adds permissive CORS headers to all responses
-func WithAnyCORS(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Allow all origins
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+// BindAddress returns the API bind address. It defaults to localhost and can
+// be overridden via BIND_ADDRESS (for example, 0.0.0.0 in containers).
+func BindAddress(port string) string {
+	bindHost := strings.TrimSpace(os.Getenv("BIND_ADDRESS"))
+	if bindHost == "" {
+		bindHost = "127.0.0.1"
+	}
 
-		// Handle preflight requests
+	return net.JoinHostPort(bindHost, port)
+}
+
+// WithCORS enforces explicit CORS defaults.
+//
+// Behaviour:
+//   - If ALLOWED_ORIGINS is not configured, cross-origin requests are rejected.
+//   - If ALLOWED_ORIGINS is configured, only those origins are allowed.
+//   - Authorization is only exposed when ALLOW_AUTH_HEADER=true.
+func WithCORS(next http.Handler) http.Handler {
+	allowedOrigins := parseAllowedOrigins(os.Getenv("ALLOWED_ORIGINS"))
+	allowAuthHeader := strings.EqualFold(strings.TrimSpace(os.Getenv("ALLOW_AUTH_HEADER")), "true")
+	allowHeaders := "Content-Type"
+	if allowAuthHeader {
+		allowHeaders = "Content-Type, Authorization"
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := strings.TrimSpace(r.Header.Get("Origin"))
+		if origin != "" {
+			if !isOriginAllowed(origin, allowedOrigins) {
+				http.Error(w, "forbidden origin", http.StatusForbidden)
+				return
+			}
+
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Vary", "Origin")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", allowHeaders)
+		}
+
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return
@@ -49,4 +81,25 @@ func WithAnyCORS(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+func parseAllowedOrigins(origins string) map[string]struct{} {
+	allowed := map[string]struct{}{}
+	for _, item := range strings.Split(origins, ",") {
+		origin := strings.TrimSpace(item)
+		if origin == "" {
+			continue
+		}
+		allowed[origin] = struct{}{}
+	}
+
+	return allowed
+}
+
+func isOriginAllowed(origin string, allowedOrigins map[string]struct{}) bool {
+	if len(allowedOrigins) == 0 {
+		return false
+	}
+	_, ok := allowedOrigins[origin]
+	return ok
 }

--- a/samples/tokens/common/fsc_test.go
+++ b/samples/tokens/common/fsc_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestBindAddress_DefaultLocalhost(t *testing.T) {
+	t.Setenv("BIND_ADDRESS", "")
+	if got, want := BindAddress("9000"), "127.0.0.1:9000"; got != want {
+		t.Fatalf("BindAddress() = %q, want %q", got, want)
+	}
+}
+
+func TestBindAddress_FromEnv(t *testing.T) {
+	t.Setenv("BIND_ADDRESS", "0.0.0.0")
+	if got, want := BindAddress("9000"), "0.0.0.0:9000"; got != want {
+		t.Fatalf("BindAddress() = %q, want %q", got, want)
+	}
+}
+
+func TestWithCORS_RejectsUnknownOriginByDefault(t *testing.T) {
+	t.Setenv("ALLOWED_ORIGINS", "")
+	t.Setenv("ALLOW_AUTH_HEADER", "")
+
+	h := WithCORS(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("handler should not be called for forbidden origin")
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/owner/accounts/alice", nil)
+	req.Header.Set("Origin", "http://evil.example")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusForbidden)
+	}
+}
+
+func TestWithCORS_AllowsConfiguredOrigin(t *testing.T) {
+	t.Setenv("ALLOWED_ORIGINS", "http://localhost:8080")
+	t.Setenv("ALLOW_AUTH_HEADER", "")
+
+	h := WithCORS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/owner/accounts/alice", nil)
+	req.Header.Set("Origin", "http://localhost:8080")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNoContent)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:8080" {
+		t.Fatalf("allow-origin = %q, want %q", got, "http://localhost:8080")
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Headers"); got != "Content-Type" {
+		t.Fatalf("allow-headers = %q, want %q", got, "Content-Type")
+	}
+}
+
+func TestWithCORS_AllowsAuthorizationHeaderWhenEnabled(t *testing.T) {
+	t.Setenv("ALLOWED_ORIGINS", "http://localhost:8080")
+	t.Setenv("ALLOW_AUTH_HEADER", "true")
+
+	h := WithCORS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/owner/accounts/alice", nil)
+	req.Header.Set("Origin", "http://localhost:8080")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNoContent)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Headers"); got != "Content-Type, Authorization" {
+		t.Fatalf("allow-headers = %q, want %q", got, "Content-Type, Authorization")
+	}
+}
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	_ = os.Unsetenv("BIND_ADDRESS")
+	_ = os.Unsetenv("ALLOWED_ORIGINS")
+	_ = os.Unsetenv("ALLOW_AUTH_HEADER")
+	os.Exit(code)
+}

--- a/samples/tokens/compose.yml
+++ b/samples/tokens/compose.yml
@@ -5,6 +5,10 @@
 
 x-service-template: &service-template
   restart: unless-stopped
+  environment:
+    - BIND_ADDRESS=0.0.0.0
+    - ALLOWED_ORIGINS=http://localhost:8080,http://127.0.0.1:8080
+    - ALLOW_AUTH_HEADER=true
   extra_hosts:
     - "committer-sidecar:host-gateway"
     - "committer-queryservice:host-gateway"
@@ -28,7 +32,7 @@ services:
       - 9001
       - 9101
     ports:
-      - 9100:9000/tcp
+      - 127.0.0.1:9100:9000/tcp
 
   endorser1:
     <<: *service-template
@@ -46,7 +50,7 @@ services:
       - 9001
       - 9301
     ports:
-      - 9300:9000/tcp
+      - 127.0.0.1:9300:9000/tcp
 
   owner1:
     <<: *service-template
@@ -63,7 +67,7 @@ services:
       - 9001
       - 9501
     ports:
-      - 9500:9000/tcp
+      - 127.0.0.1:9500:9000/tcp
 
   owner2:
     <<: *service-template
@@ -80,13 +84,13 @@ services:
       - 9001
       - 9601
     ports:
-      - 9600:9000/tcp
+      - 127.0.0.1:9600:9000/tcp
 
   swagger-ui:
     <<: *service-template
     image: swaggerapi/swagger-ui
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     environment:
       - URL=/swagger.yaml
     volumes:

--- a/samples/tokens/endorser/main.go
+++ b/samples/tokens/endorser/main.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"flag"
 	"log"
-	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -38,10 +37,10 @@ func main() {
 
 	// Simple web server
 	sh := routes.NewStrictHandler(routes.NewServer(service.NewFSC(fsc)), []routes.StrictMiddlewareFunc{})
-	h := common.WithAnyCORS(routes.HandlerFromMux(sh, http.NewServeMux()))
+	h := common.WithCORS(routes.HandlerFromMux(sh, http.NewServeMux()))
 	s := &http.Server{
 		Handler: h,
-		Addr:    net.JoinHostPort("0.0.0.0", *port),
+		Addr:    common.BindAddress(*port),
 	}
 	go s.ListenAndServe()
 

--- a/samples/tokens/issuer/main.go
+++ b/samples/tokens/issuer/main.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"flag"
 	"log"
-	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -47,10 +46,10 @@ func main() {
 
 	// Simple web server
 	sh := routes.NewStrictHandler(routes.NewServer(service.NewFSC(fsc)), []routes.StrictMiddlewareFunc{})
-	h := common.WithAnyCORS(routes.HandlerFromMux(sh, http.NewServeMux()))
+	h := common.WithCORS(routes.HandlerFromMux(sh, http.NewServeMux()))
 	s := &http.Server{
 		Handler: h,
-		Addr:    net.JoinHostPort("0.0.0.0", *port),
+		Addr:    common.BindAddress(*port),
 	}
 	go s.ListenAndServe()
 

--- a/samples/tokens/owner/main.go
+++ b/samples/tokens/owner/main.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"flag"
 	"log"
-	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -47,10 +46,10 @@ func main() {
 
 	// Simple web server
 	sh := routes.NewStrictHandler(routes.NewServer(service.NewFSC(fsc)), []routes.StrictMiddlewareFunc{})
-	h := common.WithAnyCORS(routes.HandlerFromMux(sh, http.NewServeMux()))
+	h := common.WithCORS(routes.HandlerFromMux(sh, http.NewServeMux()))
 	s := &http.Server{
 		Handler: h,
-		Addr:    net.JoinHostPort("0.0.0.0", *port),
+		Addr:    common.BindAddress(*port),
 	}
 	go s.ListenAndServe()
 

--- a/tests/check_cors_default.sh
+++ b/tests/check_cors_default.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST=${1:-localhost:9300}
+URL="http://${HOST}/endorser/init"
+
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X OPTIONS "$URL" \
+  -H "Origin: http://evil.example" \
+  -H "Access-Control-Request-Method: POST" || true)
+
+if [ "$STATUS" = "403" ]; then
+  echo "PASS: preflight rejected (403)"
+  exit 0
+fi
+
+echo "FAIL: preflight returned $STATUS"
+exit 2


### PR DESCRIPTION
 Implemented Issue hyperledger/fabric-x-samples#7 by making samples/tokens CORS and bind address secure-by-default yet configurable, restricting host port exposure (including Swagger) to localhost in compose, and adding tests/docs for verification.