### PR TITLE
Refactor server startup in `main.go` files to handle errors from ListenAndServe in token sample servers

### DIFF
--- a/samples/tokens/endorser/main.go
+++ b/samples/tokens/endorser/main.go
@@ -43,7 +43,11 @@ func main() {
 		Handler: h,
 		Addr:    net.JoinHostPort("0.0.0.0", *port),
 	}
-	go s.ListenAndServe()
+	go func() {
+		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatal(err)
+		}
+	}()
 
 	// Stop
 	stop := make(chan os.Signal, 1)

--- a/samples/tokens/endorser/main.go
+++ b/samples/tokens/endorser/main.go
@@ -43,9 +43,10 @@ func main() {
 		Handler: h,
 		Addr:    net.JoinHostPort("0.0.0.0", *port),
 	}
+	serverErr := make(chan error, 1)
 	go func() {
 		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatal(err)
+			serverErr <- err
 		}
 	}()
 
@@ -53,7 +54,11 @@ func main() {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
-	<-stop
+	select {
+	case <-stop:
+	case err := <-serverErr:
+		log.Printf("server error: %v", err)
+	}
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)
 	defer cancel()
 	s.Shutdown(ctx)

--- a/samples/tokens/issuer/main.go
+++ b/samples/tokens/issuer/main.go
@@ -52,9 +52,10 @@ func main() {
 		Handler: h,
 		Addr:    net.JoinHostPort("0.0.0.0", *port),
 	}
+	serverErr := make(chan error, 1)
 	go func() {
 		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatal(err)
+			serverErr <- err
 		}
 	}()
 
@@ -62,7 +63,11 @@ func main() {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
-	<-stop
+	select {
+	case <-stop:
+	case err := <-serverErr:
+		log.Printf("server error: %v", err)
+	}
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)
 	defer cancel()
 	s.Shutdown(ctx)

--- a/samples/tokens/issuer/main.go
+++ b/samples/tokens/issuer/main.go
@@ -52,7 +52,11 @@ func main() {
 		Handler: h,
 		Addr:    net.JoinHostPort("0.0.0.0", *port),
 	}
-	go s.ListenAndServe()
+	go func() {
+		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatal(err)
+		}
+	}()
 
 	// Stop
 	stop := make(chan os.Signal, 1)

--- a/samples/tokens/owner/main.go
+++ b/samples/tokens/owner/main.go
@@ -52,9 +52,10 @@ func main() {
 		Handler: h,
 		Addr:    net.JoinHostPort("0.0.0.0", *port),
 	}
+	serverErr := make(chan error, 1)
 	go func() {
 		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatal(err)
+			serverErr <- err
 		}
 	}()
 
@@ -62,7 +63,11 @@ func main() {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
-	<-stop
+	select {
+	case <-stop:
+	case err := <-serverErr:
+		log.Printf("server error: %v", err)
+	}
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)
 	defer cancel()
 	s.Shutdown(ctx)

--- a/samples/tokens/owner/main.go
+++ b/samples/tokens/owner/main.go
@@ -52,7 +52,11 @@ func main() {
 		Handler: h,
 		Addr:    net.JoinHostPort("0.0.0.0", *port),
 	}
-	go s.ListenAndServe()
+	go func() {
+		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatal(err)
+		}
+	}()
 
 	// Stop
 	stop := make(chan os.Signal, 1)


### PR DESCRIPTION
Fix for : hyperledger/fabric-x-samples#13 
ListenAndServe` was called in a bare goroutine, silently discarding the returned error
  - Wrapped it in an anonymous function to capture and handle the error properly
  - `http.ErrServerClosed` is excluded since it is expected during graceful shutdown

  ## Problem
  In the following files, the HTTP server was started like this:

  go s.ListenAndServe()

  If the server failed to start (e.g. port already in use), the error was silently
  dropped and the program continued running — appearing healthy but serving no requests.

  ## Affected Files
  - samples/tokens/issuer/main.go:55
  - samples/tokens/owner/main.go:55
  - samples/tokens/endorser/main.go:46

  ## Fix
  Replaced the bare goroutine with:

  go func() {
      if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
          log.Fatal(err)
      }
  }()
  
  which gracefully handle error .