### PR TITLE
feat(fxconfig): add --format flag to info command

### DIFF
--- a/tools/fxconfig/docs/README.md
+++ b/tools/fxconfig/docs/README.md
@@ -75,7 +75,13 @@ fxconfig version
 
 # Display effective configuration
 fxconfig info
+
+# Display effective configuration as environment variables
+fxconfig info --format env
 ```
+
+**`info` Flags:**
+- `--format=<yaml|env>` - Output format: `yaml` (default) or `env` (flat `FXCONFIG_*=value` pairs)
 
 ## Configuration
 
@@ -365,8 +371,11 @@ fxconfig tx submit --help          # Submit command help
 ### Check Configuration
 
 ```bash
-# Display effective configuration
+# Display effective configuration (yaml)
 fxconfig info
+
+# Display effective configuration as environment variables
+fxconfig info --format env
 
 # Test connectivity
 fxconfig namespace list

--- a/tools/fxconfig/internal/cli/v1/info.go
+++ b/tools/fxconfig/internal/cli/v1/info.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
-
 )
 
 func NewInfoCommand(ctx *CLIContext) *cobra.Command {
@@ -48,13 +47,13 @@ Examples:
 				sort.Strings(env)
 				ctx.Printer.Print(strings.Join(env, "\n") + "\n")
 			case "yaml":
-				fallthrough
-			default:
 				out, err := yaml.Marshal(ctx.Config)
 				if err != nil {
 					return err
 				}
 				ctx.Printer.Print(string(out))
+			default:
+				return fmt.Errorf("invalid --format: %s (want yaml|env)", format)
 			}
 			return nil
 		},

--- a/tools/fxconfig/internal/cli/v1/info.go
+++ b/tools/fxconfig/internal/cli/v1/info.go
@@ -7,14 +7,17 @@ SPDX-License-Identifier: Apache-2.0
 package v1
 
 import (
+	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
+
 )
 
-// NewInfoCommand returns a command that displays the effective configuration.
-// The configuration is shown as YAML after applying all overrides from
-// flags, environment variables, and config files.
 func NewInfoCommand(ctx *CLIContext) *cobra.Command {
+	var format string
 	cmd := &cobra.Command{
 		Use:   "info",
 		Short: "Display effective configuration",
@@ -39,15 +42,65 @@ Examples:
   # Show configuration as environment variables
   fxconfig info --format env`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			// TODO: add flag to show yaml/env config
-			out, err := yaml.Marshal(ctx.Config)
-			if err != nil {
-				return err
+			switch format {
+			case "env":
+				env := toEnv("FXCONFIG", ctx.Config)
+				sort.Strings(env)
+				ctx.Printer.Print(strings.Join(env, "\n") + "\n")
+			case "yaml":
+				fallthrough
+			default:
+				out, err := yaml.Marshal(ctx.Config)
+				if err != nil {
+					return err
+				}
+				ctx.Printer.Print(string(out))
 			}
-			ctx.Printer.Print(string(out))
 			return nil
 		},
 	}
 
+	cmd.Flags().StringVar(&format, "format", "yaml", "Output format (yaml|env)")
+
 	return cmd
+}
+
+func toEnv(prefix string, cfg any) []string {
+	// we use yaml marshaling as a shortcut to get a map representation of the config
+	// that respects all yaml tags and omitempty.
+	out, err := yaml.Marshal(cfg)
+	if err != nil {
+		return nil
+	}
+
+	var m map[string]any
+	if err := yaml.Unmarshal(out, &m); err != nil {
+		return nil
+	}
+
+	return flatten(prefix, m)
+}
+
+func flatten(prefix string, m map[string]any) []string {
+	var result []string
+	for k, v := range m {
+		key := strings.ToUpper(strings.ReplaceAll(k, "-", "_"))
+		if prefix != "" {
+			key = prefix + "_" + key
+		}
+
+		switch val := v.(type) {
+		case map[string]any:
+			result = append(result, flatten(key, val)...)
+		case []any:
+			var strVals []string
+			for _, item := range val {
+				strVals = append(strVals, fmt.Sprintf("%v", item))
+			}
+			result = append(result, fmt.Sprintf("%s=%s", key, strings.Join(strVals, ",")))
+		default:
+			result = append(result, fmt.Sprintf("%s=%v", key, val))
+		}
+	}
+	return result
 }

--- a/tools/fxconfig/internal/cli/v1/info.go
+++ b/tools/fxconfig/internal/cli/v1/info.go
@@ -46,7 +46,10 @@ Examples:
 		RunE: func(_ *cobra.Command, _ []string) error {
 			switch format {
 			case "env":
-				env := toEnv("FXCONFIG", ctx.Config)
+				env, err := toEnv("FXCONFIG", ctx.Config)
+				if err != nil {
+					return err
+				}
 				slices.Sort(env)
 				ctx.Printer.Print(strings.Join(env, "\n") + "\n")
 			case "yaml":
@@ -67,20 +70,20 @@ Examples:
 	return cmd
 }
 
-func toEnv(prefix string, cfg any) []string {
+func toEnv(prefix string, cfg any) ([]string, error) {
 	// we use yaml marshaling as a shortcut to get a map representation of the config
 	// that respects all yaml tags and omitempty.
 	out, err := yaml.Marshal(cfg)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	var m map[string]any
 	if err := yaml.Unmarshal(out, &m); err != nil {
-		return nil
+		return nil, err
 	}
 
-	return flatten(prefix, m)
+	return flatten(prefix, m), nil
 }
 
 func flatten(prefix string, m map[string]any) []string {

--- a/tools/fxconfig/internal/cli/v1/info.go
+++ b/tools/fxconfig/internal/cli/v1/info.go
@@ -8,7 +8,7 @@ package v1
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -44,7 +44,7 @@ Examples:
 			switch format {
 			case "env":
 				env := toEnv("FXCONFIG", ctx.Config)
-				sort.Strings(env)
+				slices.Sort(env)
 				ctx.Printer.Print(strings.Join(env, "\n") + "\n")
 			case "yaml":
 				out, err := yaml.Marshal(ctx.Config)
@@ -92,7 +92,7 @@ func flatten(prefix string, m map[string]any) []string {
 		case map[string]any:
 			result = append(result, flatten(key, val)...)
 		case []any:
-			var strVals []string
+			strVals := make([]string, 0, len(val))
 			for _, item := range val {
 				strVals = append(strVals, fmt.Sprintf("%v", item))
 			}

--- a/tools/fxconfig/internal/cli/v1/info.go
+++ b/tools/fxconfig/internal/cli/v1/info.go
@@ -15,6 +15,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// NewInfoCommand returns a command that displays the effective configuration.
+// The configuration is shown in the requested format (yaml or env) after applying
+// all overrides from flags, environment variables, and config files.
 func NewInfoCommand(ctx *CLIContext) *cobra.Command {
 	var format string
 	cmd := &cobra.Command{

--- a/tools/fxconfig/internal/cli/v1/info_test.go
+++ b/tools/fxconfig/internal/cli/v1/info_test.go
@@ -9,6 +9,7 @@ package v1
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -60,14 +61,57 @@ func TestInfoCommand_NilConfigPrintsNull(t *testing.T) {
 func TestInfoCommand_PrintsEnvConfig(t *testing.T) {
 	t.Parallel()
 
+	boolPtr := func(b bool) *bool { return &b }
+
 	var outBuf bytes.Buffer
 	ctx := &CLIContext{
 		Config: &config.Config{
 			Logging: config.LoggingConfig{
-				Level: "debug",
+				Level:  "ERROR",
+				Format: "%{color}%{level}%{color:reset} %{message}",
 			},
 			MSP: config.MSPConfig{
-				LocalMspID: "TestOrg",
+				LocalMspID: "Org1MSP",
+				ConfigPath: "/path/to/msp",
+			},
+			TLS: config.TLSConfig{
+				Enabled:        boolPtr(true),
+				ClientKeyPath:  "/path/to/client.key",
+				ClientCertPath: "/path/to/client.crt",
+				RootCertPaths:  []string{"/path/to/ca.crt"},
+			},
+			Orderer: config.OrdererConfig{
+				EndpointServiceConfig: config.EndpointServiceConfig{
+					Address:           "localhost:7050",
+					ConnectionTimeout: 30 * time.Second,
+					TLS: &config.TLSConfig{
+						Enabled:        boolPtr(true),
+						RootCertPaths:  []string{"/path/to/orderer-ca.crt"},
+						ClientCertPath: "/path/to/orderer-client.crt",
+						ClientKeyPath:  "/path/to/orderer-client.key",
+					},
+				},
+				Channel: "mychannel",
+			},
+			Queries: config.QueriesConfig{
+				EndpointServiceConfig: config.EndpointServiceConfig{
+					Address:           "localhost:7001",
+					ConnectionTimeout: 30 * time.Second,
+					TLS: &config.TLSConfig{
+						Enabled:       boolPtr(true),
+						RootCertPaths: []string{"/path/to/peer-ca.crt"},
+					},
+				},
+			},
+			Notifications: config.NotificationsConfig{
+				EndpointServiceConfig: config.EndpointServiceConfig{
+					Address:           "localhost:7001",
+					ConnectionTimeout: 30 * time.Second,
+					TLS: &config.TLSConfig{
+						Enabled: boolPtr(false),
+					},
+				},
+				WaitingTimeout: 30 * time.Second,
 			},
 		},
 		Printer: cliio.NewCLIPrinter(&outBuf, &outBuf, cliio.FormatTable),
@@ -81,6 +125,33 @@ func TestInfoCommand_PrintsEnvConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	output := outBuf.String()
-	require.Contains(t, output, "FXCONFIG_LOGGING_LEVEL=debug")
-	require.Contains(t, output, "FXCONFIG_MSP_LOCALMSPID=TestOrg")
+	require.Contains(t, output, "FXCONFIG_LOGGING_LEVEL=ERROR")
+	require.Contains(t, output, "FXCONFIG_MSP_LOCALMSPID=Org1MSP")
+	require.Contains(t, output, "FXCONFIG_MSP_CONFIGPATH=/path/to/msp")
+	require.Contains(t, output, "FXCONFIG_TLS_ENABLED=true")
+	require.Contains(t, output, "FXCONFIG_TLS_CLIENTKEY=/path/to/client.key")
+	require.Contains(t, output, "FXCONFIG_TLS_CLIENTCERT=/path/to/client.crt")
+	require.Contains(t, output, "FXCONFIG_TLS_ROOTCERTS=/path/to/ca.crt")
+	require.Contains(t, output, "FXCONFIG_ORDERER_ADDRESS=localhost:7050")
+	require.Contains(t, output, "FXCONFIG_ORDERER_CHANNEL=mychannel")
+	require.Contains(t, output, "FXCONFIG_QUERIES_ADDRESS=localhost:7001")
+	require.Contains(t, output, "FXCONFIG_NOTIFICATIONS_ADDRESS=localhost:7001")
+}
+
+func TestInfoCommand_InvalidFormat(t *testing.T) {
+	t.Parallel()
+
+	var outBuf bytes.Buffer
+	ctx := &CLIContext{
+		Config:  &config.Config{},
+		Printer: cliio.NewCLIPrinter(&outBuf, &outBuf, cliio.FormatTable),
+	}
+
+	cmd := NewInfoCommand(ctx)
+	err := cmd.Flags().Set("format", "json")
+	require.NoError(t, err)
+
+	err = cmd.RunE(cmd, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid --format: json (want yaml|env)")
 }

--- a/tools/fxconfig/internal/cli/v1/info_test.go
+++ b/tools/fxconfig/internal/cli/v1/info_test.go
@@ -134,6 +134,7 @@ func TestInfoCommand_PrintsEnvConfig(t *testing.T) {
 	require.Contains(t, output, "FXCONFIG_TLS_ROOTCERTS=/path/to/ca.crt")
 	require.Contains(t, output, "FXCONFIG_ORDERER_ADDRESS=localhost:7050")
 	require.Contains(t, output, "FXCONFIG_ORDERER_CHANNEL=mychannel")
+	require.Contains(t, output, "FXCONFIG_ORDERER_CONNECTIONTIMEOUT=30s")
 	require.Contains(t, output, "FXCONFIG_QUERIES_ADDRESS=localhost:7001")
 	require.Contains(t, output, "FXCONFIG_NOTIFICATIONS_ADDRESS=localhost:7001")
 }

--- a/tools/fxconfig/internal/cli/v1/info_test.go
+++ b/tools/fxconfig/internal/cli/v1/info_test.go
@@ -56,3 +56,31 @@ func TestInfoCommand_NilConfigPrintsNull(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, outBuf.String(), "null")
 }
+
+func TestInfoCommand_PrintsEnvConfig(t *testing.T) {
+	t.Parallel()
+
+	var outBuf bytes.Buffer
+	ctx := &CLIContext{
+		Config: &config.Config{
+			Logging: config.LoggingConfig{
+				Level: "debug",
+			},
+			MSP: config.MSPConfig{
+				LocalMspID: "TestOrg",
+			},
+		},
+		Printer: cliio.NewCLIPrinter(&outBuf, &outBuf, cliio.FormatTable),
+	}
+
+	cmd := NewInfoCommand(ctx)
+	err := cmd.Flags().Set("format", "env")
+	require.NoError(t, err)
+
+	err = cmd.RunE(cmd, nil)
+	require.NoError(t, err)
+
+	output := outBuf.String()
+	require.Contains(t, output, "FXCONFIG_LOGGING_LEVEL=debug")
+	require.Contains(t, output, "FXCONFIG_MSP_LOCALMSPID=TestOrg")
+}

--- a/tools/fxconfig/internal/cli/v1/info_test.go
+++ b/tools/fxconfig/internal/cli/v1/info_test.go
@@ -138,6 +138,35 @@ func TestInfoCommand_PrintsEnvConfig(t *testing.T) {
 	require.Contains(t, output, "FXCONFIG_NOTIFICATIONS_ADDRESS=localhost:7001")
 }
 
+func TestInfoCommand_PrintsEnvConfig_MultipleCerts(t *testing.T) {
+	t.Parallel()
+
+	boolPtr := func(b bool) *bool { return &b }
+
+	var outBuf bytes.Buffer
+	ctx := &CLIContext{
+		Config: &config.Config{
+			TLS: config.TLSConfig{
+				Enabled:        boolPtr(true),
+				ClientKeyPath:  "/path/to/client.key",
+				ClientCertPath: "/path/to/client.crt",
+				RootCertPaths:  []string{"/path/to/ca1.crt", "/path/to/ca2.crt"},
+			},
+		},
+		Printer: cliio.NewCLIPrinter(&outBuf, &outBuf, cliio.FormatTable),
+	}
+
+	cmd := NewInfoCommand(ctx)
+	err := cmd.Flags().Set("format", "env")
+	require.NoError(t, err)
+
+	err = cmd.RunE(cmd, nil)
+	require.NoError(t, err)
+
+	output := outBuf.String()
+	require.Contains(t, output, "FXCONFIG_TLS_ROOTCERTS=/path/to/ca1.crt,/path/to/ca2.crt")
+}
+
 func TestInfoCommand_InvalidFormat(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- Improvement (improvement to code, performance, etc)

#### Description

This PR resolves an existing TODO in the `info` command by adding a `--format` flag, allowing users to view the effective configuration in either `yaml` (default) or `env` format.