### PR TITLE
fxconfig: add env format output for info command

### DIFF
--- a/tools/fxconfig/internal/cli/v1/flags.go
+++ b/tools/fxconfig/internal/cli/v1/flags.go
@@ -55,3 +55,11 @@ func (f *waitFlag) bind(cmd *cobra.Command) {
 	cmd.Flags().BoolVar((*bool)(f), "wait", false,
 		"Wait for transaction to be finalized and return status code")
 }
+
+// formatFlag represents an output format flag.
+type formatFlag string
+
+func (f *formatFlag) bind(cmd *cobra.Command) {
+	cmd.Flags().StringVar((*string)(f), "format", "yaml",
+		"Output format: yaml or env")
+}

--- a/tools/fxconfig/internal/cli/v1/info.go
+++ b/tools/fxconfig/internal/cli/v1/info.go
@@ -7,6 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package v1
 
 import (
+	"fmt"
+	"maps"
+	"reflect"
+	"sort"
+	"strings"
+
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -15,6 +21,8 @@ import (
 // The configuration is shown as YAML after applying all overrides from
 // flags, environment variables, and config files.
 func NewInfoCommand(ctx *CLIContext) *cobra.Command {
+	var format formatFlag
+
 	cmd := &cobra.Command{
 		Use:   "info",
 		Short: "Display effective configuration",
@@ -39,15 +47,138 @@ Examples:
   # Show configuration as environment variables
   fxconfig info --format env`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			// TODO: add flag to show yaml/env config
-			out, err := yaml.Marshal(ctx.Config)
-			if err != nil {
-				return err
+			var output string
+
+			switch format {
+			case "yaml":
+				out, err := yaml.Marshal(ctx.Config)
+				if err != nil {
+					return err
+				}
+				output = string(out)
+			case "env":
+				envVars := configToEnvVars("FXCONFIG", ctx.Config)
+				if len(envVars) == 0 {
+					output = "null"
+					break
+				}
+
+				keys := make([]string, 0, len(envVars))
+				for key := range envVars {
+					keys = append(keys, key)
+				}
+				sort.Strings(keys)
+
+				var b strings.Builder
+				for _, key := range keys {
+					_, _ = fmt.Fprintf(&b, "%s=%s\n", key, envVars[key])
+				}
+				output = b.String()
+			default:
+				return fmt.Errorf("unsupported format %q (supported formats are yaml and env)", format)
 			}
-			ctx.Printer.Print(string(out))
+			ctx.Printer.Print(output)
 			return nil
 		},
 	}
 
+	// adds flags related to info
+	format.bind(cmd)
+
 	return cmd
+}
+
+// configToEnvVars converts configuration to environment variable format.
+// Each field is output as FXCONFIG_<FIELD>=<VALUE>.
+func configToEnvVars(envPrefix string, s any) map[string]string { //nolint:gocognit
+	result := make(map[string]string)
+	if s == nil {
+		return result
+	}
+
+	val := reflect.ValueOf(s)
+	typ := reflect.TypeOf(s)
+
+	// Dereference pointer to struct
+	if val.Kind() == reflect.Pointer {
+		if val.IsNil() {
+			return result
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		fieldVal := val.Field(i)
+
+		if !field.IsExported() {
+			continue
+		}
+
+		tag := field.Tag.Get("mapstructure")
+		if tag == "" || tag == "-" {
+			continue
+		}
+
+		// Handle squash
+		if tag == ",squash" {
+			nested := configToEnvVars(envPrefix, fieldVal.Interface())
+			maps.Copy(result, nested)
+			continue
+		}
+
+		tagName, _, _ := strings.Cut(tag, ",")
+		if tagName == "" {
+			continue
+		}
+		envKey := envPrefix + "_" + strings.ToUpper(tagName)
+
+		ft := field.Type
+		isPtr := ft.Kind() == reflect.Pointer
+		if isPtr {
+			if fieldVal.IsNil() {
+				continue
+			}
+			ft = ft.Elem()
+		}
+
+		if ft.Kind() == reflect.Slice {
+			sliceValue := fieldVal
+			if isPtr {
+				sliceValue = fieldVal.Elem()
+			}
+			if sliceValue.Len() > 0 {
+				var items []string
+				for j := range sliceValue.Len() {
+					items = append(items, fmt.Sprintf("%v",
+						sliceValue.Index(j).Interface()))
+				}
+				result[envKey] = strings.Join(items, ",")
+			}
+			continue
+		}
+
+		// Recurse into nested struct
+		if ft.Kind() == reflect.Struct {
+			nested := configToEnvVars(envKey, fieldVal.Interface())
+			maps.Copy(result, nested)
+			continue
+		}
+
+		// Handle primitive values
+		var value any
+		if isPtr {
+			value = fieldVal.Elem().Interface()
+		} else {
+			value = fieldVal.Interface()
+		}
+
+		// Ignore zero values such as empty strings, 0, false, etc.
+		if !reflect.ValueOf(value).IsZero() {
+			result[envKey] = fmt.Sprintf("%v", value)
+		}
+	}
+
+	return result
 }

--- a/tools/fxconfig/internal/cli/v1/info_test.go
+++ b/tools/fxconfig/internal/cli/v1/info_test.go
@@ -25,6 +25,10 @@ func TestNewInfoCommand(t *testing.T) {
 	require.Equal(t, "info", cmd.Use)
 	require.NotEmpty(t, cmd.Short)
 	require.NotNil(t, cmd.RunE)
+
+	flag := cmd.Flags().Lookup("format")
+	require.NotNil(t, flag)                 // ensure the --format flag is defined
+	require.Equal(t, "yaml", flag.DefValue) // default should be "yaml"
 }
 
 func TestInfoCommand_PrintsYAMLConfig(t *testing.T) {
@@ -42,6 +46,32 @@ func TestInfoCommand_PrintsYAMLConfig(t *testing.T) {
 	require.NotEmpty(t, outBuf.String())
 }
 
+func TestInfoCommand_PrintsEnvVars(t *testing.T) {
+	t.Parallel()
+
+	var outBuf bytes.Buffer
+	ctx := &CLIContext{
+		Config: &config.Config{
+			Logging: config.LoggingConfig{Level: "info"},
+			TLS:     config.TLSConfig{ClientKeyPath: "test-client-key-path"},
+		},
+		Printer: cliio.NewCLIPrinter(&outBuf, &outBuf, cliio.FormatTable),
+	}
+
+	cmd := NewInfoCommand(ctx)
+	cmd.SetArgs([]string{"--format", "env"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.Equal(t, "env", cmd.Flag("format").Value.String()) // ensure --format env is applied
+
+	output := outBuf.String()
+	require.NotEmpty(t, output)
+
+	require.Contains(t, output, "FXCONFIG_LOGGING_LEVEL=info")
+	require.Contains(t, output, "FXCONFIG_TLS_CLIENTKEY=test-client-key-path")
+}
+
 func TestInfoCommand_NilConfigPrintsNull(t *testing.T) {
 	t.Parallel()
 
@@ -54,5 +84,13 @@ func TestInfoCommand_NilConfigPrintsNull(t *testing.T) {
 	cmd := NewInfoCommand(ctx)
 	err := cmd.RunE(cmd, nil)
 	require.NoError(t, err)
+	require.Equal(t, "yaml", cmd.Flag("format").Value.String()) // ensure --format yaml is default
+	require.Contains(t, outBuf.String(), "null")
+
+	outBuf.Reset()
+	cmd.SetArgs([]string{"--format", "env"})
+	err = cmd.Execute()
+	require.NoError(t, err)
+	require.Equal(t, "env", cmd.Flag("format").Value.String()) // ensure --format env is applied
 	require.Contains(t, outBuf.String(), "null")
 }


### PR DESCRIPTION
#### Type of change
- New feature
- Test update

#### Description
Add the --format flag to the fxconfig info command to display configuration as environment variables. I have implemented the configToEnvVars() function to recursively convert config structs into environment variables with the FXCONFIG_ prefix referenced from [load.go](https://github.com/hyperledger/fabric-x/blob/12d958de8fb2387f7a22a9ed71152f29a23f898d/tools/fxconfig/internal/config/load.go#L103-L146). It supports nested structs, pointers, slices, and squashed fields. Zero values (such as false, 0, and others) are omitted from the output; however, they can be included if needed.
 
#### Additional details 
Yaml format is default
```
balaji > ./bin/fxconfig info
logging:
    level: error
tls:
    enabled: false
orderer:
    connectionTimeout: 30s
    tls:
        enabled: false
    channel: mychannel
queries:
    connectionTimeout: 30s
    tls:
        enabled: false
notifications:
    connectionTimeout: 30s
    tls:
        enabled: false
    waitingTimeout: 30s
```
```
balaji > ./bin/fxconfig info --format yaml
logging:
    level: error
tls:
    enabled: false
orderer:
    connectionTimeout: 30s
    tls:
        enabled: false
    channel: mychannel
queries:
    connectionTimeout: 30s
    tls:
        enabled: false
notifications:
    connectionTimeout: 30s
    tls:
        enabled: false
    waitingTimeout: 30s
```
tls-enabled is ignored, due to the false value
```
balaji > ./bin/fxconfig info --format env
FXCONFIG_LOGGING_LEVEL=error
FXCONFIG_NOTIFICATIONS_CONNECTIONTIMEOUT=30s
FXCONFIG_NOTIFICATIONS_WAITINGTIMEOUT=30s
FXCONFIG_ORDERER_CHANNEL=mychannel
FXCONFIG_ORDERER_CONNECTIONTIMEOUT=30s
FXCONFIG_QUERIES_CONNECTIONTIMEOUT=30s
```
