### PR TITLE
fix(fxconfig): propagate stream errors in NotificationClient

### DIFF
--- a/tools/fxconfig/internal/client/notifications.go
+++ b/tools/fxconfig/internal/client/notifications.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -32,6 +33,12 @@ type NotificationClient struct {
 
 	subscribers   map[string][]chan int
 	subscribersMu sync.RWMutex
+
+	// streamErr holds the error that caused the stream to terminate.
+	// Atomically stored; checked by Subscribe() before sending requests.
+	streamErr atomic.Pointer[error]
+	// streamReady is set to true once the gRPC stream is open and accepting requests.
+	streamReady atomic.Bool
 }
 
 // NewNotificationClient creates a notification client with the provided configuration.
@@ -58,8 +65,7 @@ func NewNotificationClient(cfg config.NotificationsConfig) (*NotificationClient,
 
 	go func() {
 		if err := nc.listen(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			fmt.Printf("error: Notification listener stream terminated unexpectedly: %s\n", err)
-			// logger.Errorf("Notification listener stream terminated unexpectedly for %s: %s", key, err)
+			logger.Errorf("Notification listener stream terminated unexpectedly: %s", err)
 		}
 	}()
 
@@ -88,6 +94,11 @@ func (n *NotificationClient) Subscribe(ctx context.Context, txID string) (chan i
 	if len(subscribers) > 0 {
 		// we already have an active subscription for this txID
 		return receiverCh, nil
+	}
+
+	// Fail fast if the stream has previously failed.
+	if err := n.streamErr.Load(); err != nil {
+		return nil, *err
 	}
 
 	// setup request
@@ -146,8 +157,11 @@ func wait(ctx context.Context, subscription chan int) (int, error) {
 func (n *NotificationClient) listen(ctx context.Context) error {
 	notifyStream, err := n.notifyClient.OpenNotificationStream(ctx)
 	if err != nil {
+		n.streamErr.Store(&err)
 		return err
 	}
+	n.streamReady.Store(true)
+
 	// Use the base context for errgroup
 	g, gCtx := errgroup.WithContext(ctx)
 
@@ -232,10 +246,17 @@ func (n *NotificationClient) listen(ctx context.Context) error {
 
 	err = g.Wait()
 
+	// Capture the error from the group before cleanup.
+	if err != nil && !errors.Is(err, context.Canceled) {
+		n.streamErr.Store(&err)
+	}
+
 	// Cleanup subscribers map when listen() exits
 	n.subscribersMu.Lock()
 	clear(n.subscribers)
 	n.subscribersMu.Unlock()
+
+	n.streamReady.Store(false)
 
 	return err
 }

--- a/tools/fxconfig/internal/client/notifications.go
+++ b/tools/fxconfig/internal/client/notifications.go
@@ -37,8 +37,6 @@ type NotificationClient struct {
 	// streamErr holds the error that caused the stream to terminate.
 	// Atomically stored; checked by Subscribe() before sending requests.
 	streamErr atomic.Pointer[error]
-	// streamReady is set to true once the gRPC stream is open and accepting requests.
-	streamReady atomic.Bool
 }
 
 // NewNotificationClient creates a notification client with the provided configuration.
@@ -83,17 +81,16 @@ func (n *NotificationClient) Close() error {
 // Subscribe registers interest in a transaction's status and returns a channel for notifications.
 // Multiple subscribers to the same txID share a single upstream subscription.
 func (n *NotificationClient) Subscribe(ctx context.Context, txID string) (chan int, error) {
-	receiverCh := make(chan int, 1)
+	// Apply timeout to prevent blocking on requestQueue send.
+	ctx, cancel := context.WithTimeout(ctx, n.cfg.WaitingTimeout)
+	defer cancel()
 
-	// Fail fast if the stream has previously failed.
+	// Fail fast if the stream has previously failed — check before any state mutation.
 	if err := n.streamErr.Load(); err != nil {
 		return nil, *err
 	}
 
-	// Fail fast if the stream is not yet ready.
-	if !n.streamReady.Load() {
-		return nil, errors.New("notification stream is not ready")
-	}
+	receiverCh := make(chan int, 1)
 
 	n.subscribersMu.Lock()
 	defer n.subscribersMu.Unlock()
@@ -165,7 +162,6 @@ func (n *NotificationClient) listen(ctx context.Context) error {
 		n.streamErr.Store(&err)
 		return err
 	}
-	n.streamReady.Store(true)
 
 	// Use the base context for errgroup
 	g, gCtx := errgroup.WithContext(ctx)
@@ -260,8 +256,6 @@ func (n *NotificationClient) listen(ctx context.Context) error {
 	n.subscribersMu.Lock()
 	clear(n.subscribers)
 	n.subscribersMu.Unlock()
-
-	n.streamReady.Store(false)
 
 	return err
 }

--- a/tools/fxconfig/internal/client/notifications.go
+++ b/tools/fxconfig/internal/client/notifications.go
@@ -92,7 +92,7 @@ func (n *NotificationClient) Subscribe(ctx context.Context, txID string) (chan i
 
 	// Fail fast if the stream is not yet ready.
 	if !n.streamReady.Load() {
-		return nil, fmt.Errorf("notification stream is not ready")
+		return nil, errors.New("notification stream is not ready")
 	}
 
 	n.subscribersMu.Lock()

--- a/tools/fxconfig/internal/client/notifications.go
+++ b/tools/fxconfig/internal/client/notifications.go
@@ -85,6 +85,16 @@ func (n *NotificationClient) Close() error {
 func (n *NotificationClient) Subscribe(ctx context.Context, txID string) (chan int, error) {
 	receiverCh := make(chan int, 1)
 
+	// Fail fast if the stream has previously failed.
+	if err := n.streamErr.Load(); err != nil {
+		return nil, *err
+	}
+
+	// Fail fast if the stream is not yet ready.
+	if !n.streamReady.Load() {
+		return nil, fmt.Errorf("notification stream is not ready")
+	}
+
 	n.subscribersMu.Lock()
 	defer n.subscribersMu.Unlock()
 
@@ -94,11 +104,6 @@ func (n *NotificationClient) Subscribe(ctx context.Context, txID string) (chan i
 	if len(subscribers) > 0 {
 		// we already have an active subscription for this txID
 		return receiverCh, nil
-	}
-
-	// Fail fast if the stream has previously failed.
-	if err := n.streamErr.Load(); err != nil {
-		return nil, *err
 	}
 
 	// setup request

--- a/tools/fxconfig/internal/client/notifications_test.go
+++ b/tools/fxconfig/internal/client/notifications_test.go
@@ -135,7 +135,6 @@ func TestNotificationClient_Subscribe_DuplicateSubscription(t *testing.T) {
 	t.Parallel()
 
 	nc := newTestNotificationClient(time.Second)
-	nc.streamReady.Store(true) // Simulate stream being ready
 	// Pre-populate a subscriber so the second subscribe is a duplicate
 	// and won't send to the requestQueue (which would block without a listener).
 	nc.subscribers["tx1"] = []chan int{make(chan int, 1)}
@@ -149,7 +148,6 @@ func TestNotificationClient_Subscribe_ContextCanceled(t *testing.T) {
 	t.Parallel()
 
 	nc := newTestNotificationClient(time.Second)
-	nc.streamReady.Store(true) // Simulate stream being ready
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -161,7 +159,6 @@ func TestNotificationClient_Subscribe_SendsRequest(t *testing.T) {
 	t.Parallel()
 
 	nc := newTestNotificationClient(time.Second)
-	nc.streamReady.Store(true) // Simulate stream being ready
 
 	// Consume the request in a background goroutine to unblock Subscribe.
 	go func() { <-nc.requestQueue }()
@@ -171,21 +168,10 @@ func TestNotificationClient_Subscribe_SendsRequest(t *testing.T) {
 	require.NotNil(t, ch)
 }
 
-func TestNotificationClient_Subscribe_StreamNotReady(t *testing.T) {
-	t.Parallel()
-
-	nc := newTestNotificationClient(time.Second)
-	// streamReady is false by default
-
-	_, err := nc.Subscribe(t.Context(), "tx1")
-	require.ErrorContains(t, err, "notification stream is not ready")
-}
-
 func TestNotificationClient_Subscribe_StreamError(t *testing.T) {
 	t.Parallel()
 
 	nc := newTestNotificationClient(time.Second)
-	nc.streamReady.Store(true) // Simulate stream being ready
 	// Simulate a stream error
 	expectedErr := errors.New("stream connection lost")
 	nc.streamErr.Store(&expectedErr)
@@ -194,6 +180,18 @@ func TestNotificationClient_Subscribe_StreamError(t *testing.T) {
 	_, err := nc.Subscribe(t.Context(), "tx1")
 	require.ErrorIs(t, err, expectedErr)
 	require.Empty(t, nc.subscribers, "subscribers map should not be modified when streamErr is set")
+}
+
+func TestNotificationClient_Subscribe_Timeout(t *testing.T) {
+	t.Parallel()
+
+	nc := newTestNotificationClient(time.Millisecond)
+	// Don't consume requestQueue — Subscribe should time out waiting to send.
+
+	_, err := nc.Subscribe(t.Context(), "tx1")
+	require.Error(t, err)
+	// Should get DeadlineExceeded since the context timeout is short.
+	require.ErrorContains(t, err, "deadline exceeded")
 }
 
 // Close tests

--- a/tools/fxconfig/internal/client/notifications_test.go
+++ b/tools/fxconfig/internal/client/notifications_test.go
@@ -8,6 +8,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -134,6 +135,7 @@ func TestNotificationClient_Subscribe_DuplicateSubscription(t *testing.T) {
 	t.Parallel()
 
 	nc := newTestNotificationClient(time.Second)
+	nc.streamReady.Store(true) // Simulate stream being ready
 	// Pre-populate a subscriber so the second subscribe is a duplicate
 	// and won't send to the requestQueue (which would block without a listener).
 	nc.subscribers["tx1"] = []chan int{make(chan int, 1)}
@@ -147,6 +149,7 @@ func TestNotificationClient_Subscribe_ContextCanceled(t *testing.T) {
 	t.Parallel()
 
 	nc := newTestNotificationClient(time.Second)
+	nc.streamReady.Store(true) // Simulate stream being ready
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -158,6 +161,7 @@ func TestNotificationClient_Subscribe_SendsRequest(t *testing.T) {
 	t.Parallel()
 
 	nc := newTestNotificationClient(time.Second)
+	nc.streamReady.Store(true) // Simulate stream being ready
 
 	// Consume the request in a background goroutine to unblock Subscribe.
 	go func() { <-nc.requestQueue }()
@@ -165,6 +169,31 @@ func TestNotificationClient_Subscribe_SendsRequest(t *testing.T) {
 	ch, err := nc.Subscribe(t.Context(), "tx1")
 	require.NoError(t, err)
 	require.NotNil(t, ch)
+}
+
+func TestNotificationClient_Subscribe_StreamNotReady(t *testing.T) {
+	t.Parallel()
+
+	nc := newTestNotificationClient(time.Second)
+	// streamReady is false by default
+
+	_, err := nc.Subscribe(t.Context(), "tx1")
+	require.ErrorContains(t, err, "notification stream is not ready")
+}
+
+func TestNotificationClient_Subscribe_StreamError(t *testing.T) {
+	t.Parallel()
+
+	nc := newTestNotificationClient(time.Second)
+	nc.streamReady.Store(true) // Simulate stream being ready
+	// Simulate a stream error
+	expectedErr := fmt.Errorf("stream connection lost")
+	nc.streamErr.Store(&expectedErr)
+
+	// Verify that subscribers map is NOT modified when streamErr is set
+	_, err := nc.Subscribe(t.Context(), "tx1")
+	require.ErrorIs(t, err, expectedErr)
+	require.Empty(t, nc.subscribers, "subscribers map should not be modified when streamErr is set")
 }
 
 // Close tests

--- a/tools/fxconfig/internal/client/notifications_test.go
+++ b/tools/fxconfig/internal/client/notifications_test.go
@@ -8,7 +8,7 @@ package client
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 	"time"
 
@@ -187,7 +187,7 @@ func TestNotificationClient_Subscribe_StreamError(t *testing.T) {
 	nc := newTestNotificationClient(time.Second)
 	nc.streamReady.Store(true) // Simulate stream being ready
 	// Simulate a stream error
-	expectedErr := fmt.Errorf("stream connection lost")
+	expectedErr := errors.New("stream connection lost")
 	nc.streamErr.Store(&expectedErr)
 
 	// Verify that subscribers map is NOT modified when streamErr is set


### PR DESCRIPTION
# fix(fxconfig): propagate stream errors in NotificationClient

 #### Type of change

 - Bug fix #104

 #### Description

 When the fxconfig CLI submits a transaction with `--wait`, it hangs forever if the committer's notification stream can't be established. No error is returned — just silence.

 The root cause was in `tools/fxconfig/internal/client/notifications.go`. When `NewNotificationClient` failed to open the gRPC bidirectional stream, the error was printed to stdout and the goroutine ended silently — but the client was still returned as healthy. Calling `Subscribe()` would then send requests into a dead stream, causing `WaitForEvent` to hang indefinitely.

 What changed:

 - Added `streamErr atomic.Pointer[error]` and `streamReady atomic.Bool` to the `NotificationClient` struct to track stream health
 - When `listen()` fails to open the stream or terminates with an error, the error is now stored atomically
 - `Subscribe()` now checks `streamErr` before queuing a request — if the stream is dead, it returns the stored error immediately instead of silently forwarding to a broken stream
 - Replaced `fmt.Printf` with proper `logger.Errorf` and removed the dead commented logger line


 #### Additional details

 - `go test ./internal/client/...` — passes
- `go build ./tools/fxconfig/...` — compiles cleanly