### PR TITLE
fix: return non-zero exit code for failed tx submit with --wait

### DIFF
--- a/tools/fxconfig/internal/cli/v1/tx_submit.go
+++ b/tools/fxconfig/internal/cli/v1/tx_submit.go
@@ -69,7 +69,10 @@ Examples:
 					fmt.Sprintf("Transaction status: %s", committerpb.Status_name[int32(status)]), //nolint:gosec
 				)
 				if status != int(committerpb.Status_COMMITTED) {
-					return fmt.Errorf("transaction failed with status: %s", committerpb.Status_name[int32(status)]) //nolint:gosec
+					return fmt.Errorf(
+						"transaction failed with status: %s",
+						committerpb.Status_name[int32(status)], //nolint:gosec
+					)
 				}
 				return nil
 			}

--- a/tools/fxconfig/internal/cli/v1/tx_submit.go
+++ b/tools/fxconfig/internal/cli/v1/tx_submit.go
@@ -68,6 +68,9 @@ Examples:
 				ctx.Printer.Print(
 					fmt.Sprintf("Transaction status: %s", committerpb.Status_name[int32(status)]), //nolint:gosec
 				)
+				if status != int(committerpb.Status_COMMITTED) {
+					return fmt.Errorf("transaction failed with status: %s", committerpb.Status_name[int32(status)]) //nolint:gosec
+				}
 				return nil
 			}
 

--- a/tools/fxconfig/internal/cli/v1/tx_submit_test.go
+++ b/tools/fxconfig/internal/cli/v1/tx_submit_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
 
 	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/cli/v1/cliio"
 )
@@ -59,7 +60,7 @@ func TestTxSubmitCommand_SubmitWithWait(t *testing.T) {
 
 	mockApp := &testApp{}
 	mockApp.On("SubmitTransactionWithWait", mock.Anything, "tx-123", mock.AnythingOfType("*applicationpb.Tx")).
-		Return(0, nil)
+		Return(int(committerpb.Status_COMMITTED), nil)
 
 	var outBuf bytes.Buffer
 	ctx := &CLIContext{

--- a/tools/fxconfig/internal/cli/v1/tx_submit_test.go
+++ b/tools/fxconfig/internal/cli/v1/tx_submit_test.go
@@ -78,6 +78,33 @@ func TestTxSubmitCommand_SubmitWithWait(t *testing.T) {
 	mockApp.AssertExpectations(t)
 }
 
+func TestTxSubmitCommand_SubmitWithWaitFailed(t *testing.T) {
+	t.Parallel()
+
+	txFile := writeTxFile(t, "tx-123", &applicationpb.Tx{})
+
+	mockApp := &testApp{}
+	mockApp.On("SubmitTransactionWithWait", mock.Anything, "tx-123", mock.AnythingOfType("*applicationpb.Tx")).
+		Return(int(committerpb.Status_ABORTED_SIGNATURE_INVALID), nil)
+
+	var outBuf bytes.Buffer
+	ctx := &CLIContext{
+		App:                mockApp,
+		Printer:            cliio.NewCLIPrinter(&outBuf, &outBuf, cliio.FormatTable),
+		IOTransactionCodec: &cliio.JSONCodec{},
+	}
+
+	cmd := newTxSubmitCommand(ctx)
+	cmd.SetOut(&outBuf)
+	cmd.SetArgs([]string{txFile, "--wait"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "transaction failed with status: ABORTED_SIGNATURE_INVALID")
+	require.Contains(t, outBuf.String(), "Transaction status: ABORTED_SIGNATURE_INVALID")
+	mockApp.AssertExpectations(t)
+}
+
 func TestTxSubmitCommand_AppError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
This PR fixes exit code behavior for fxconfig tx submit --wait so failed transaction outcomes return a non-zero exit code.

## Problem
The command printed the final transaction status but still exited with code 0 for failure statuses. This caused automation and CI workflows to treat failed transactions as successful.

## Root Cause
In the wait path, the command always returned nil after printing transaction status, regardless of the status value.

## Solution
The command now returns an error when the final status is not COMMITTED, and returns nil only for COMMITTED.
Status printing remains unchanged and still uses the enum name mapping.
Type casts are intentionally preserved because TxStatus is int while committerpb.Status is int32.

## Impact
- No change to successful transaction behavior
- CLI status output format is unchanged
- Failure cases now correctly produce a non-zero exit code

## Testing
- Updated the success wait test to assert committed status behavior
- Added a failure wait test using ABORTED_SIGNATURE_INVALID status
- Verified tx submit tests pass with expected success and failure semantics

fixes #96 