### PR TITLE
Fix sample application startup with test-committer and classic fabric

### DIFF
--- a/samples/tokens/Dockerfile
+++ b/samples/tokens/Dockerfile
@@ -18,7 +18,8 @@ COPY . .
 
 RUN --mount=type=cache,target=/go-cache \
     --mount=type=cache,target=/gomod-cache \
-    cd "${NODE_TYPE}" && go build -tags "${PLATFORM}" -o /app
+    if [ "${PLATFORM}" = "xdev" ]; then BUILD_TAGS="fabricx"; else BUILD_TAGS="${PLATFORM}"; fi && \
+    cd "${NODE_TYPE}" && go build -tags "${BUILD_TAGS}" -o /app
 
 FROM busybox
 

--- a/samples/tokens/Makefile
+++ b/samples/tokens/Makefile
@@ -19,7 +19,7 @@ include ./app.mk
 # Install the utilities needed to run the components on the targeted remote hosts (e.g. make install-prerequisites).
 .PHONY: install-prerequisites
 install-prerequisites: install-prerequisites-fabric
-	./install-fabric.sh --fabric-version 3.1.1
+	./install-fabric.sh --fabric-version 3.1.4
 	go mod tidy
 
 # Build all the artifacts and binaries, and copy them to the application folders

--- a/samples/tokens/README.md
+++ b/samples/tokens/README.md
@@ -12,33 +12,32 @@ The **Token SDK Sample** demonstrates how to:
 
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
-- [About the Sample](#about-the-sample)
-  - [Components](#components)
-    - [Application services](#application-services)
-    - [Fabric(x) Blockchain Network](#fabricx-blockchain-network)
-  - [Application](#application)
-  - [UTXO Model](#utxo-model)
-  - [Deep Dive: What Happens During a Transfer?](#deep-dive-what-happens-during-a-transfer)
-- [Running the sample](#running-the-sample)
-- [Prerequisites](#prerequisites)
-- [Default option: Fabric-X with Ansible](#default-option-fabric-x-with-ansible)
-  - [Requirements](#requirements)
-  - [Installation](#installation)
-  - [Setup Fabric-X](#setup-fabric-x)
-- [Option 2: Fabric-X test container](#option-2-fabric-x-test-container)
-- [Option 3: Fabric v3](#option-3-fabric-v3)
-  - [Setup Fabric v3](#setup-fabric-v3)
-  - [Start the Network and Application](#start-the-network-and-application)
-- [Interacting with the Application](#interacting-with-the-application)
-- [Example: Issue tokens](#example-issue-tokens)
-- [Example: Transfer tokens](#example-transfer-tokens)
-- [Teardown and cleanup](#teardown-and-cleanup)
-- [Development](#development)
-- [Debug mode](#debug-mode)
-  - [VSCode](#vscode)
-  - [Running the binaries](#running-the-binaries)
-- [Troubleshooting](#troubleshooting)
+- [Token SDK Sample](#token-sdk-sample)
+  - [Table of Contents](#table-of-contents)
+  - [About the Sample](#about-the-sample)
+    - [Components](#components)
+      - [Application services](#application-services)
+      - [Fabric(x) Blockchain Network](#fabricx-blockchain-network)
+    - [Application](#application)
+    - [UTXO Model](#utxo-model)
+    - [Deep Dive: What Happens During a Transfer?](#deep-dive-what-happens-during-a-transfer)
+  - [Running the sample](#running-the-sample)
+  - [Prerequisites](#prerequisites)
+  - [Default option: Fabric-X with Ansible](#default-option-fabric-x-with-ansible)
+    - [Requirements](#requirements)
+    - [Installation](#installation)
+    - [Setup Fabric-X](#setup-fabric-x)
+  - [Option 2: Fabric-X test container](#option-2-fabric-x-test-container)
+  - [Option 3: Fabric v3](#option-3-fabric-v3)
+  - [Interacting with the Application](#interacting-with-the-application)
+  - [Example: Issue tokens](#example-issue-tokens)
+  - [Example: Transfer tokens](#example-transfer-tokens)
+  - [Teardown and cleanup](#teardown-and-cleanup)
+  - [Development](#development)
+  - [Debug mode](#debug-mode)
+    - [VSCode](#vscode)
+    - [Running the binaries](#running-the-binaries)
+  - [Troubleshooting](#troubleshooting)
 
 ## About the Sample
 
@@ -161,29 +160,11 @@ make install-prerequisites
 
 ### Setup Fabric-X
 
-Make sure that the crypto is cleared and let the scripts know you want to use ansible:
+Let the scripts know you want to use ansible (not strictly necessary as this is the default).
+Then generate the crypto material.
 
 ```shell
-make teardown
-make clean
 export PLATFORM=fabricx
-make setup
-```
-
-Then, like with the test container:
-
-```shell
-make start
-curl -X POST http://localhost:9300/endorser/init
-```
-
-## Option 2: Fabric-X test container
-
-The quickest way to get going: a test version of Fabric-X in a single docker container! Even if you want to use different backends, we suggest to start here.
-
-First generate the necessary crypto material:
-
-```shell
 make setup
 ```
 
@@ -203,22 +184,42 @@ This creates:
 
 The relevant crypto material is copied to the folders in the conf/\* directories.
 
-The following first command starts the Fabric-X test container, creates a namespace, and runs the application in docker containers. The second command ensures that the parameters for the network (cryptographic material, the idemix issuer identity for the accounts, the token issuer certificate) are registered on the ledger.
+Then start the application and initialize it. The "init" endpoint records the cryptographic
+parameters and configuration which we generated in the "setup" step on the blockchain. This will be the anchor for the token transactions.
 
 ```shell
 make start
 curl -X POST http://localhost:9300/endorser/init
 ```
 
-Now open <http://localhost:8080> in your browser to see the other API endpoints, or scroll down to follow some `curl` commands.
+## Option 2: Fabric-X test container
+
+The quickest way for development: a test version of Fabric-X in a single docker container!
+First make sure that the crypto from the ansible network is cleared.
+
+```shell
+make teardown
+make clean
+```
+
+Let the scripts know you want to use the test container ('xdev') and generate the necessary crypto material:
+
+```shell
+export PLATFORM=xdev
+make setup
+```
+
+Start the application and initialize it. 
+
+```shell
+make start
+curl -X POST http://localhost:9300/endorser/init
+```
 
 ## Option 3: Fabric v3
 
-Run the same application against a classic Fabric v3 network.
-
-### Setup Fabric v3
-
-First, clean up any previous state and set Fabric v3:
+It's also possible to the same application against a classic Fabric network. Clean up any previous
+state and setup the classic Fabric material:
 
 ```shell
 make teardown
@@ -226,8 +227,6 @@ make clean
 export PLATFORM=fabric3
 make setup
 ```
-
-### Start the Network and Application
 
 Start the Fabric network, create the namespace (chaincode), and start the application services. For Fabric 3, you don't have to call the Init endpoint; this is taken care of when installing the chaincode.
 

--- a/samples/tokens/compose-xdev.yml
+++ b/samples/tokens/compose-xdev.yml
@@ -13,7 +13,7 @@ services:
     environment:
       - SC_SIDECAR_ORDERER_IDENTITY_MSP_DIR=/root/config/crypto/peerOrganizations/org1.example.com/peers/SC.org1.example.com/msp
       - SC_SIDECAR_ORDERER_IDENTITY_MSP_ID=Org1MSP
-      - SC_SIDECAR_ORDERER_CHANNEL_ID=mychannel
+      - SC_SIDECAR_ORDERER_CHANNEL_ID=arma
       - SC_SIDECAR_ORDERER_SIGNED_ENVELOPES=true
       - SC_QUERY_SERVICE_SERVER_ENDPOINT=:7001
       - SC_ORDERER_BLOCK_SIZE=1

--- a/samples/tokens/fabricx_ansible.mk
+++ b/samples/tokens/fabricx_ansible.mk
@@ -33,7 +33,7 @@ CONTAINER_CLI ?= docker
 install-prerequisites-fabric:
 	python3 -m venv $(VENV_DIR)
 	$(VENV_DIR)/bin/python -m pip install --upgrade pip
-	$(VENV_DIR)/bin/pip install -r $(ANSIBLE_PATH)/requirements.txt
+	$(VENV_DIR)/bin/python -m pip install -r $(ANSIBLE_PATH)/requirements.txt
 	ansible-galaxy collection install -r $(ANSIBLE_PATH)/requirements.yml
 	ansible-playbook "$(PLAYBOOK_PATH)/01-install-control-node-prerequisites.yaml"
 	ansible-playbook hyperledger.fabricx.install_prerequisites --extra-vars '{"target_hosts": "$(TARGET_HOSTS)"}'

--- a/samples/tokens/fabricx_dev.mk
+++ b/samples/tokens/fabricx_dev.mk
@@ -16,7 +16,7 @@ install-prerequisites-fabric:
 .PHONY: setup-fabric
 setup-fabric:
 	@go tool cryptogen generate --config crypto-config.yaml --output crypto
-	@go tool configtxgen --channelID mychannel --profile OrgsChannel --outputBlock crypto/sc-genesis-block.proto.bin
+	@go tool configtxgen --channelID arma --profile OrgsChannel --outputBlock crypto/sc-genesis-block.proto.bin
 	@CRYPTO_DIR=crypto ./scripts/cp_fabricx.sh
 
 # Clean all the artifacts (configs and bins) built on the controller node (e.g. make clean).
@@ -33,7 +33,7 @@ start-fabric:
 	@$(CONTAINER_CLI) network inspect fabric_test >/dev/null 2>&1 || $(CONTAINER_CLI) network create fabric_test
 	@$(CONTAINER_CLI) compose -f compose-xdev.yml up -d --wait && sleep 2
 	@echo "install namespace:"
-	@go tool fxconfig namespace create token_namespace --channel=mychannel --orderer=localhost:7050 --mspID=Org1MSP \
+	@go tool fxconfig namespace create token_namespace --channel=arma --orderer=localhost:7050 --mspID=Org1MSP \
 		--mspConfigPath=crypto/peerOrganizations/org1.example.com/users/channel_admin@org1.example.com/msp \
 		--pk=crypto/peerOrganizations/org1.example.com/users/endorser@org1.example.com/msp/signcerts/endorser@org1.example.com-cert.pem
 	@until go tool fxconfig namespace list --endpoint=localhost:7001 2>/dev/null | grep -q token_namespace; do sleep 1; echo "waiting for namespace to be created..."; done


### PR DESCRIPTION
#### Type of change

Bug fix

#### Description

The test committer version of the sample application was not working, as the channel in the configuration "arma" did not match the channel used in the test committer "mychannel". This is fixed, and the README.md order has been made more readable.

Also, updating the Fabric version to 3.1.4; the sample application installs chaincode to create the namespace and this was failing on newer versions of docker (see: https://github.com/hyperledger/fabric/issues/5350).

#### Related issues

N/A