### PR TITLE
chore: update actions/checkout v4→v6 and actions/setup-go v5→v6

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU for cross-platform builds
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/samples-tests.yml
+++ b/.github/workflows/samples-tests.yml
@@ -26,10 +26,10 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Updates all GitHub Actions workflow files to use the latest versions of the
`actions/checkout` and `actions/setup-go` actions as specified in issue #115.

Changes across 4 workflow files:
- `actions/checkout`: v4 → v6
- `actions/setup-go`: v5 → v6

No logic changes — version bumps only.

#### Additional details (Optional)

All 4 workflow files were updated in a single commit:
- `.github/workflows/build-image.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/samples-tests.yml`
- `.github/workflows/tests.yml`

#### Related issues

Closes #115