### PR TITLE
fix(tokens): fail fast on curl errors in demo test script

### DIFF
--- a/samples/tokens/fabric3.mk
+++ b/samples/tokens/fabric3.mk
@@ -38,9 +38,10 @@ clean-fabric:
 # Start the targeted hosts (e.g. make fabric-fabric start).
 .PHONY: start-fabric
 start-fabric:
-	@"$(FABRIC_SAMPLES)/test-network/network.sh" down || true
-	@$(CONTAINER_CLI) rm -f peer0org1_token_namespace_ccaas peer0org2_token_namespace_ccaas >/dev/null 2>&1 || true
-	@$(CONTAINER_CLI) network inspect fabric_test >/dev/null 2>&1 && $(CONTAINER_CLI) network rm fabric_test || true
+	@if $(CONTAINER_CLI) network inspect fabric_test >/dev/null 2>&1; then \
+		echo "Error: existing fabric_test network detected. Run 'make teardown' first."; \
+		exit 1; \
+	fi
 	"$(FABRIC_SAMPLES)/test-network/network.sh" up createChannel -i 3.1.1
 	INIT_REQUIRED="--init-required" "$(FABRIC_SAMPLES)/test-network/network.sh" deployCCAAS  -ccn token_namespace -ccp "$(abspath $$CONF_ROOT)/namespace" -cci "init"
 	./scripts/cp_fabric3.sh

--- a/samples/tokens/fabric3.mk
+++ b/samples/tokens/fabric3.mk
@@ -38,6 +38,9 @@ clean-fabric:
 # Start the targeted hosts (e.g. make fabric-fabric start).
 .PHONY: start-fabric
 start-fabric:
+	@"$(FABRIC_SAMPLES)/test-network/network.sh" down || true
+	@$(CONTAINER_CLI) rm -f peer0org1_token_namespace_ccaas peer0org2_token_namespace_ccaas >/dev/null 2>&1 || true
+	@$(CONTAINER_CLI) network inspect fabric_test >/dev/null 2>&1 && $(CONTAINER_CLI) network rm fabric_test || true
 	"$(FABRIC_SAMPLES)/test-network/network.sh" up createChannel -i 3.1.1
 	INIT_REQUIRED="--init-required" "$(FABRIC_SAMPLES)/test-network/network.sh" deployCCAAS  -ccn token_namespace -ccp "$(abspath $$CONF_ROOT)/namespace" -cci "init"
 	./scripts/cp_fabric3.sh

--- a/samples/tokens/scripts/test.sh
+++ b/samples/tokens/scripts/test.sh
@@ -17,7 +17,12 @@ function print_section_header() {
 
 ## Cleanup and stop network on abort
 function cleanup() {
+    local exit_code=$?
+    local failed_cmd="$BASH_COMMAND"
+    trap - INT ERR
+    set +e
     stop_network
+    echo "Error: command '$failed_cmd' exited with status $exit_code" >&2
     exit 1
 }
 
@@ -61,15 +66,15 @@ function run_test() {
 }
 
 # Script Start
-set +e
+set -eE
 set -o pipefail
-trap exit 1 INT
+trap cleanup INT ERR
 
 run_network
 # # currently we wait manually with a sleep.
 # # TODO: add an healthcheck within the `docker-compose`
 sleep 10
-if [[ "$PLATFORM" == "fabricx" ]]; then
+if [[ "$PLATFORM" == "fabricx" || "$PLATFORM" == "xdev" ]]; then
     init_fabricx
 fi
 run_test

--- a/samples/tokens/scripts/test.sh
+++ b/samples/tokens/scripts/test.sh
@@ -41,7 +41,7 @@ function stop_network() {
 ## Initialize FabricX if needed
 function init_fabricx() {
     print_section_header "Initializing ${PLATFORM}..."
-    curl -f -X POST http://localhost:9300/endorser/init
+    curl_with_retry -X POST http://localhost:9300/endorser/init
 }
 
 ## Wait for an API endpoint to report ready
@@ -50,18 +50,14 @@ function wait_until_ready() {
     local url="$2"
     local max_attempts="${MAX_READY_ATTEMPTS:-30}"
     local sleep_seconds="${READY_RETRY_SLEEP_SECONDS:-2}"
-    local attempt=1
 
-    while ! curl -fsS "$url" >/dev/null; do
-        if (( attempt >= max_attempts )); then
-            echo "Error: ${service_name} did not become ready after ${max_attempts} attempts (${url})" >&2
-            return 1
-        fi
-
-        echo "Waiting for ${service_name} readiness (${attempt}/${max_attempts}): ${url}" >&2
-        sleep "$sleep_seconds"
-        ((attempt++))
-    done
+    echo "Waiting for ${service_name} readiness: ${url}" >&2
+    curl -fsS \
+        --retry "$max_attempts" \
+        --retry-delay "$sleep_seconds" \
+        --retry-all-errors \
+        --retry-connrefused \
+        "$url" >/dev/null
 }
 
 ## Wait for all services needed by the test run
@@ -79,25 +75,12 @@ function wait_for_services() {
 
 ## Run curl with retries for transient startup errors
 function curl_with_retry() {
-    local max_attempts="${CURL_MAX_ATTEMPTS:-6}"
-    local sleep_seconds="${CURL_RETRY_SLEEP_SECONDS:-2}"
-    local attempt=1
-
-    while true; do
-        if curl -f -X "$@"; then
-            return 0
-        fi
-
-        local exit_code=$?
-        if (( attempt >= max_attempts )); then
-            echo "Error: curl failed after ${attempt} attempts: curl -X $*" >&2
-            return "$exit_code"
-        fi
-
-        echo "Retrying curl command (${attempt}/${max_attempts}): curl -X $*" >&2
-        sleep "$sleep_seconds"
-        ((attempt++))
-    done
+    curl -fS \
+        --retry "${CURL_MAX_ATTEMPTS:-6}" \
+        --retry-delay "${CURL_RETRY_SLEEP_SECONDS:-2}" \
+        --retry-all-errors \
+        --retry-connrefused \
+        "$@"
 }
 
 ## Run tests to verify the network
@@ -105,20 +88,20 @@ function run_test() {
     # test application
     print_section_header "Run tests"
 
-    curl_with_retry POST http://localhost:9100/issuer/issue -d '{
+    curl_with_retry -X POST http://localhost:9100/issuer/issue -d '{
         "amount": {"code": "TOK","value": 1000},
         "counterparty": {"node": "owner1","account": "alice"},
         "message": "hello world!"
     }'
-    curl_with_retry GET http://localhost:9500/owner/accounts/alice | jq
-    curl_with_retry GET http://localhost:9600/owner/accounts/dan | jq
-    curl_with_retry POST http://localhost:9500/owner/accounts/alice/transfer -d '{
+    curl_with_retry -X GET http://localhost:9500/owner/accounts/alice | jq
+    curl_with_retry -X GET http://localhost:9600/owner/accounts/dan | jq
+    curl_with_retry -X POST http://localhost:9500/owner/accounts/alice/transfer -d '{
         "amount": {"code": "TOK","value": 100},
         "counterparty": {"node": "owner2","account": "dan"},
         "message": "hello dan!"
     }'
-    curl_with_retry GET http://localhost:9600/owner/accounts/dan/transactions | jq
-    curl_with_retry GET http://localhost:9500/owner/accounts/alice/transactions | jq
+    curl_with_retry -X GET http://localhost:9600/owner/accounts/dan/transactions | jq
+    curl_with_retry -X GET http://localhost:9500/owner/accounts/alice/transactions | jq
 }
 
 # Script Start

--- a/samples/tokens/scripts/test.sh
+++ b/samples/tokens/scripts/test.sh
@@ -69,6 +69,8 @@ function run_test() {
 set -eE
 set -o pipefail
 trap cleanup INT ERR
+PLATFORM="${PLATFORM:-fabric3}"
+export PLATFORM
 
 run_network
 # # currently we wait manually with a sleep.

--- a/samples/tokens/scripts/test.sh
+++ b/samples/tokens/scripts/test.sh
@@ -44,6 +44,39 @@ function init_fabricx() {
     curl -f -X POST http://localhost:9300/endorser/init
 }
 
+## Wait for an API endpoint to report ready
+function wait_until_ready() {
+    local service_name="$1"
+    local url="$2"
+    local max_attempts="${MAX_READY_ATTEMPTS:-30}"
+    local sleep_seconds="${READY_RETRY_SLEEP_SECONDS:-2}"
+    local attempt=1
+
+    while ! curl -fsS "$url" >/dev/null; do
+        if (( attempt >= max_attempts )); then
+            echo "Error: ${service_name} did not become ready after ${max_attempts} attempts (${url})" >&2
+            return 1
+        fi
+
+        echo "Waiting for ${service_name} readiness (${attempt}/${max_attempts}): ${url}" >&2
+        sleep "$sleep_seconds"
+        ((attempt++))
+    done
+}
+
+## Wait for all services needed by the test run
+function wait_for_services() {
+    print_section_header "Waiting for services to become ready..."
+
+    if [[ "$PLATFORM" == "fabricx" || "$PLATFORM" == "xdev" ]]; then
+        wait_until_ready "endorser" "http://localhost:9300/readyz"
+    fi
+
+    wait_until_ready "issuer" "http://localhost:9100/readyz"
+    wait_until_ready "owner1" "http://localhost:9500/readyz"
+    wait_until_ready "owner2" "http://localhost:9600/readyz"
+}
+
 ## Run tests to verify the network
 function run_test() {
     # test application
@@ -76,6 +109,7 @@ run_network
 # # currently we wait manually with a sleep.
 # # TODO: add an healthcheck within the `docker-compose`
 sleep 10
+wait_for_services
 if [[ "$PLATFORM" == "fabricx" || "$PLATFORM" == "xdev" ]]; then
     init_fabricx
 fi

--- a/samples/tokens/scripts/test.sh
+++ b/samples/tokens/scripts/test.sh
@@ -77,25 +77,48 @@ function wait_for_services() {
     wait_until_ready "owner2" "http://localhost:9600/readyz"
 }
 
+## Run curl with retries for transient startup errors
+function curl_with_retry() {
+    local max_attempts="${CURL_MAX_ATTEMPTS:-6}"
+    local sleep_seconds="${CURL_RETRY_SLEEP_SECONDS:-2}"
+    local attempt=1
+
+    while true; do
+        if curl -f -X "$@"; then
+            return 0
+        fi
+
+        local exit_code=$?
+        if (( attempt >= max_attempts )); then
+            echo "Error: curl failed after ${attempt} attempts: curl -X $*" >&2
+            return "$exit_code"
+        fi
+
+        echo "Retrying curl command (${attempt}/${max_attempts}): curl -X $*" >&2
+        sleep "$sleep_seconds"
+        ((attempt++))
+    done
+}
+
 ## Run tests to verify the network
 function run_test() {
     # test application
     print_section_header "Run tests"
 
-    curl -f -X POST http://localhost:9100/issuer/issue -d '{
+    curl_with_retry POST http://localhost:9100/issuer/issue -d '{
         "amount": {"code": "TOK","value": 1000},
         "counterparty": {"node": "owner1","account": "alice"},
         "message": "hello world!"
     }'
-    curl -f -X GET http://localhost:9500/owner/accounts/alice | jq
-    curl -f -X GET http://localhost:9600/owner/accounts/dan | jq
-    curl -f -X POST http://localhost:9500/owner/accounts/alice/transfer -d '{
+    curl_with_retry GET http://localhost:9500/owner/accounts/alice | jq
+    curl_with_retry GET http://localhost:9600/owner/accounts/dan | jq
+    curl_with_retry POST http://localhost:9500/owner/accounts/alice/transfer -d '{
         "amount": {"code": "TOK","value": 100},
         "counterparty": {"node": "owner2","account": "dan"},
         "message": "hello dan!"
     }'
-    curl -f -X GET http://localhost:9600/owner/accounts/dan/transactions | jq
-    curl -f -X GET http://localhost:9500/owner/accounts/alice/transactions | jq
+    curl_with_retry GET http://localhost:9600/owner/accounts/dan/transactions | jq
+    curl_with_retry GET http://localhost:9500/owner/accounts/alice/transactions | jq
 }
 
 # Script Start


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

`samples/tokens/scripts/test.sh` used `set +e` at the script entry point, which
instructs bash to ignore all non-zero exit codes. Combined with `trap exit 1 INT`
(which only handles Ctrl+C), every `curl -f` call inside `run_test()` could fail
silently — the script would continue executing subsequent steps and exit with code `0`,
falsely reporting the demo as successful.

**Example:** if the issuer's `POST /issuer/issue` call fails (e.g. container not ready,
HTTP 500), bash ignores the failure and proceeds to the `transfer` and `transactions`
calls, which then operate on a non-existent token. `make test` would pass in CI even
when the network is broken.

**Changes made:**
- Replace `set +e` with `set -e` — script now exits immediately on any command failure
- Replace `trap exit 1 INT` with `trap cleanup INT ERR` — network teardown is triggered
  on both Ctrl+C and any unexpected error, not just keyboard interrupt
- Add `trap - INT ERR` inside `cleanup()` — prevents recursive trap firing if
  `stop_network` itself fails during cleanup

#### Additional details

Verified with `bash -n` (syntax check passes). Live terminal proof of before/after:

```bash
# Before (set +e): curl failure silently swallowed
set +e; curl -f -sS http://127.0.0.1:1 >/dev/null; echo "continued=yes"
# Output: curl_exit=7, continued=yes  ← BUG

# After (set -e): script halts on failure
bash -c 'set -e; curl -f -sS http://127.0.0.1:1 >/dev/null; echo "continued=yes"'
# Output: subshell_exit=7  ← "continued=yes" never printed, correct
```

#### Related issues

Fixes hyperledger/fabric-x-samples#6