### PR TITLE
fix(fxconfig): clean up subscriber on context cancellation

### DIFF
--- a/tools/fxconfig/internal/client/notifications.go
+++ b/tools/fxconfig/internal/client/notifications.go
@@ -80,14 +80,33 @@ func (n *NotificationClient) Subscribe(ctx context.Context, txID string) (chan i
 	receiverCh := make(chan int, 1)
 
 	n.subscribersMu.Lock()
-	defer n.subscribersMu.Unlock()
-
 	subscribers := n.subscribers[txID]
 	n.subscribers[txID] = append(subscribers, receiverCh)
+	isFirst := len(subscribers) == 0
+	n.subscribersMu.Unlock()
 
-	if len(subscribers) > 0 {
+	if !isFirst {
 		// we already have an active subscription for this txID
 		return receiverCh, nil
+	}
+
+	// rollback removes the subscriber we just added if the context is
+	// canceled before the upstream request is queued. Without this cleanup
+	// a stale entry would prevent future subscriptions from opening a new
+	// upstream request, causing them to hang indefinitely.
+	rollback := func() {
+		n.subscribersMu.Lock()
+		defer n.subscribersMu.Unlock()
+		subs := n.subscribers[txID]
+		for i, ch := range subs {
+			if ch == receiverCh {
+				n.subscribers[txID] = append(subs[:i], subs[i+1:]...)
+				break
+			}
+		}
+		if len(n.subscribers[txID]) == 0 {
+			delete(n.subscribers, txID)
+		}
 	}
 
 	// setup request
@@ -101,6 +120,7 @@ func (n *NotificationClient) Subscribe(ctx context.Context, txID string) (chan i
 	// check if our ctx is still open
 	select {
 	case <-ctx.Done():
+		rollback()
 		return nil, ctx.Err()
 	default:
 	}
@@ -108,6 +128,7 @@ func (n *NotificationClient) Subscribe(ctx context.Context, txID string) (chan i
 	// try to push to request queue
 	select {
 	case <-ctx.Done():
+		rollback()
 		return nil, ctx.Err()
 	case n.requestQueue <- req:
 	}


### PR DESCRIPTION
### Problem

`Subscribe()` adds a receiver channel to the `subscribers` map before checking whether the context is still valid.

If the context is already canceled (or gets canceled while waiting to enqueue the request), the function returns an error but leaves the channel in the map.

Subsequent calls for the same `txID` see an existing subscriber and assume an upstream request is already active, so they skip sending a new request. This leads to the caller hanging indefinitely.

---

### Fix

* Release the mutex before any blocking operations
* Add rollback logic to remove the subscriber on context cancellation
* Delete the map entry if no subscribers remain

---

### Notes

* The rollback removes only the channel created by the current call (using pointer equality)
* No locks are held during blocking operations

---

### Testing

* Existing tests pass, including `TestNotificationClient_Subscribe_ContextCanceled`

---

Closes #109
