### PR TITLE
fix: make Makefile cross-platform for Windows native terminals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,19 @@
 .SUFFIXES:
 MAKEFLAGS += --no-builtin-rules
 
+# Cross-platform shell command abstraction
+ifeq ($(OS),Windows_NT)
+    MKDIR   = if not exist $(subst /,\,$1) mkdir $(subst /,\,$1)
+    RM      = if exist $(subst /,\,$(1)) rmdir /s /q $(subst /,\,$(1))
+    TOUCH   = type nul > $(subst /,\,$1)
+    SET_ENV = set $1=$2 &&
+else
+    MKDIR   = mkdir -p $1
+    RM      = rm -rf $1
+    TOUCH   = touch $1
+    SET_ENV = $1=$2
+endif
+
 BUILD_DIR ?= bin
 
 PKGNAME = github.com/hyperledger/fabric-x-common
@@ -58,13 +71,13 @@ $(TOOLS_EXES): %: $(BUILD_DIR)/% ## Builds a native binary
 $(BUILD_DIR)/%: GO_LDFLAGS = $(METADATA_VAR:%=-X $(PKGNAME)/common/metadata.%)
 $(BUILD_DIR)/%:
 	@echo "Building $@"
-	@mkdir -p $(@D)
-	@GOBIN=$(abspath $(@D)) go install -tags "$(GO_TAGS)" -ldflags "$(GO_LDFLAGS)" -buildvcs=false $(pkgmap.$(@F))
-	@touch $@
+	@$(call MKDIR,$(@D))
+	@$(call SET_ENV,GOBIN,$(abspath $(@D))) go install -tags "$(GO_TAGS)" -ldflags "$(GO_LDFLAGS)" -buildvcs=false $(pkgmap.$(@F))
+	@$(call TOUCH,$@)
 
 .PHONY: clean
 clean: ## Cleans the build area
-	-@rm -rf $(BUILD_DIR)
+	-@$(call RM,$(BUILD_DIR))
 
 # Run lint
 # TODO: fix existing lint issues (to find them, remove --new-from-rev=origin/main option)


### PR DESCRIPTION
## Summary
This PR fixes #133 by enabling native Windows environments to execute `make tools` and `make clean` out of the box, without requiring Git Bash or MSYS2.

## Details
Previously, the [Makefile](cci:7://file:///c:/Users/Windows/Desktop/fabric-x/Makefile:0:0-0:0) relied on inline Unix-specific shell commands like `@mkdir -p`, `rm -rf`, and inline environment variable assignments (`GOBIN=... cmd`). These naturally fail on Windows CMD or PowerShell. 

I've abstracted these into cross-platform macros at the top of the [Makefile](cci:7://file:///c:/Users/Windows/Desktop/fabric-x/Makefile:0:0-0:0):
- `$(call MKDIR,...)`
- `$(call RM,...)`
- `$(call TOUCH,...)`
- `$(call SET_ENV,...)`

On Linux/macOS, these evaluate to the exact same Unix flags `mkdir -p`, `rm -rf`, `touch`, and inline variables as before, so this does not alter or break the existing CI/Linux environments. 
On Windows, they expand into their CMD-compatible equivalents (e.g. `if not exist...`, `rmdir /s /q`).

## Verification
- Tested `make clean` and `make tools` natively on Windows and confirmed all 4 binaries build successfully into the `bin/` dir. 
- Leaves existing Linux workflows 100% untouched.

Fixes #133
