### PR TITLE
  fix(fxconfig)!: enable TLS by default to prevent plaintext fallback vulnerability

### DIFF
--- a/tools/fxconfig/internal/cli/v1/root.go
+++ b/tools/fxconfig/internal/cli/v1/root.go
@@ -11,10 +11,13 @@ package v1
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/app"
 	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/cli/v1/cliio"
 	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/config"
 )
+
+var rootLogger = flogging.MustGetLogger("root")
 
 // NewRootCommand constructs and returns the root command for fxconfig.
 // It sets up configuration loading, flag registration, and all subcommands.
@@ -48,6 +51,12 @@ Configuration can be provided via:
 			cfg, err := config.Load(opts...)
 			if err != nil {
 				return err
+			}
+
+			// Warn if TLS is disabled for any service (secure-by-default)
+			if !cfg.Orderer.TLS.IsEnabled() || !cfg.Queries.TLS.IsEnabled() || !cfg.Notifications.TLS.IsEnabled() {
+				rootLogger.Warn("TLS is disabled for one or more services — " +
+					"connections will be unencrypted. This is insecure and not recommended for production.")
 			}
 
 			// set our config and printer in our context

--- a/tools/fxconfig/internal/config/config.go
+++ b/tools/fxconfig/internal/config/config.go
@@ -60,7 +60,7 @@ type MSPConfig struct {
 //
 //nolint:revive,lll
 type TLSConfig struct {
-	Enabled            *bool    `mapstructure:"enabled" yaml:"enabled,omitempty" desc:"Enable/disable TLS" default:"false"`
+	Enabled            *bool    `mapstructure:"enabled" yaml:"enabled,omitempty" desc:"Enable/disable TLS" default:"true"`
 	ClientKeyPath      string   `mapstructure:"clientKey" yaml:"clientKey,omitempty" desc:"Path to TLS client private key"`
 	ClientCertPath     string   `mapstructure:"clientCert" yaml:"clientCert,omitempty" desc:"Path to TLS client certificate"`
 	RootCertPaths      []string `mapstructure:"rootCerts" yaml:"rootCerts,omitempty" desc:"Paths to TLS root certificates"`
@@ -68,10 +68,10 @@ type TLSConfig struct {
 }
 
 // Normalize ensures the TLS config has an explicit enabled flag.
-// Sets enabled to false if not specified.
+// Sets enabled to true if not specified.
 func (c *TLSConfig) Normalize() {
 	if c.Enabled == nil {
-		enabled := false
+		enabled := true
 		c.Enabled = &enabled
 	}
 }

--- a/tools/fxconfig/internal/config/config_test.go
+++ b/tools/fxconfig/internal/config/config_test.go
@@ -44,7 +44,7 @@ func TestTLSConfig_Normalize(t *testing.T) {
 		cfg      *TLSConfig
 		wantBool bool
 	}{
-		{"nil Enabled", &TLSConfig{}, false},
+		{"nil Enabled", &TLSConfig{}, true},
 		{"already false", &TLSConfig{Enabled: boolPtr(false)}, false},
 		{"already true", &TLSConfig{Enabled: boolPtr(true)}, true},
 	}

--- a/tools/fxconfig/internal/config/load_test.go
+++ b/tools/fxconfig/internal/config/load_test.go
@@ -423,6 +423,8 @@ queries:
 
 notifications:
   address: localhost:7002
+  tls:
+    enabled: false
 `
 	err := os.WriteFile(configPath, []byte(configContent), 0o600)
 	require.NoError(t, err)


### PR DESCRIPTION
 ## Summary

  Enable TLS by default across all service configurations (orderer, queries, notifications). Previously TLS was disabled by default.

  ## Breaking Change 

  **TLS is now enabled by default.** 

  If you upgrade to this version and don't have TLS configured, you may see:
  rootCertPaths must not be empty

  **New users** must either:
  - Configure TLS with `rootCerts`, or
  - Explicitly set `tls.enabled: false`

  **Existing users** can add `tls.enabled: false` to restore previous behavior.                                                                                                            
   
  ## Changes                                                                                                                                                                               
                  
  - TLS now defaults to `enabled: true` instead of `false`
  - `Normalize()` sets `Enabled=true` when nil
  - TLS warning moved to config load time (single centralized warning instead of per-client)
  - Integration tests updated with explicit `tls.enabled: false` (testcontainers use `--insecure` flag)
  - Added `assert.False` message for Queries TLS assertion for consistency

  ## Migration

  **Enable TLS (recommended for production):**
  ```yaml
  tls:
    enabled: true
    rootCerts:
      - /path/to/ca.crt

  Disable TLS (not recommended for production):
  tls:
    enabled: false
```
 Fixes #108
  Test Plan

  - Unit tests pass
  - Integration tests pass 