### PR TITLE
fix: replace panic with error returns in endorse.go

### DIFF
--- a/tools/fxconfig/internal/app/create.go
+++ b/tools/fxconfig/internal/app/create.go
@@ -27,8 +27,13 @@ func (*AdminApp) CreateNamespace(_ context.Context, input *DeployNamespaceInput)
 		return nil, err
 	}
 
+	txID, err := transaction.GenerateTxID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate transaction ID: %w", err)
+	}
+
 	out := &DeployNamespaceOutput{
-		TxID: transaction.GenerateTxID(),
+		TxID: txID,
 		Tx:   transaction.CreateNamespacesTx(nsPolicy, input.NsID, input.Version),
 	}
 

--- a/tools/fxconfig/internal/transaction/endorse.go
+++ b/tools/fxconfig/internal/transaction/endorse.go
@@ -100,17 +100,19 @@ func identity(signer msp.SigningIdentity) (*msppb.Identity, error) {
 }
 
 // GenerateTxID generates a unique transaction ID using SHA-256 hash of a random nonce.
-func GenerateTxID() string {
-	nonce := readNonce(nil)
+func GenerateTxID() (string, error) {
+	nonce, err := readNonce(nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate tx ID: %w", err)
+	}
 	hasher := sha256.New()
 	hasher.Write(nonce)
-	return hex.EncodeToString(hasher.Sum(nil))
+	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
 // readNonce reads a byte array of the given size from the source.
-// It panics if the read fails, or cannot read the requested size.
-// "crypto/rand" and "math/rand" never fail and always returns the correct length.
-func readNonce(source io.Reader) []byte {
+// If source is nil, crypto/rand.Reader is used.
+func readNonce(source io.Reader) ([]byte, error) {
 	if source == nil {
 		source = rand.Reader
 	}
@@ -119,11 +121,11 @@ func readNonce(source io.Reader) []byte {
 	value := make([]byte, size)
 	n, err := source.Read(value)
 	if err != nil {
-		panic(fmt.Errorf("error while creating nonce: %w", err))
+		return nil, fmt.Errorf("error while creating nonce: %w", err)
 	}
 	if n != size {
-		panic(fmt.Errorf("cannot read enough bytes for nonce actual: %d wanted: %d", n, size))
+		return nil, fmt.Errorf("cannot read enough bytes for nonce actual: %d wanted: %d", n, size)
 	}
 
-	return value
+	return value, nil
 }

--- a/tools/fxconfig/internal/transaction/endorse_test.go
+++ b/tools/fxconfig/internal/transaction/endorse_test.go
@@ -193,18 +193,74 @@ func TestGenerateTxID(t *testing.T) {
 	t.Run("returns valid hex string", func(t *testing.T) {
 		t.Parallel()
 
-		id := GenerateTxID()
+		id, err := GenerateTxID()
+		require.NoError(t, err)
 		require.NotEmpty(t, id)
 
 		// SHA-256 produces 32 bytes → 64 hex characters
 		require.Len(t, id, 64)
-		_, err := hex.DecodeString(id)
-		require.NoError(t, err, "txID should be valid hex")
+		_, decErr := hex.DecodeString(id)
+		require.NoError(t, decErr, "txID should be valid hex")
 	})
 
 	t.Run("each call returns a unique ID", func(t *testing.T) {
 		t.Parallel()
-		a, b := GenerateTxID(), GenerateTxID()
+
+		a, err := GenerateTxID()
+		require.NoError(t, err)
+		b, err := GenerateTxID()
+		require.NoError(t, err)
 		require.NotEqual(t, a, b)
 	})
+}
+
+func TestReadNonce(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns error on reader failure", func(t *testing.T) {
+		t.Parallel()
+
+		failReader := &errReader{err: errors.New("read failed")}
+		nonce, err := readNonce(failReader)
+		require.Error(t, err)
+		require.Nil(t, nonce)
+		require.Contains(t, err.Error(), "error while creating nonce")
+	})
+
+	t.Run("returns error on short read", func(t *testing.T) {
+		t.Parallel()
+
+		shortReader := &shortReader{data: []byte("short")}
+		nonce, err := readNonce(shortReader)
+		require.Error(t, err)
+		require.Nil(t, nonce)
+		require.Contains(t, err.Error(), "cannot read enough bytes for nonce")
+	})
+
+	t.Run("succeeds with valid reader", func(t *testing.T) {
+		t.Parallel()
+
+		nonce, err := readNonce(nil)
+		require.NoError(t, err)
+		require.Len(t, nonce, 24)
+	})
+}
+
+// errReader is an io.Reader that always returns an error.
+type errReader struct {
+	err error
+}
+
+func (r *errReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+// shortReader is an io.Reader that returns fewer bytes than requested.
+type shortReader struct {
+	data []byte
+}
+
+func (r *shortReader) Read(p []byte) (int, error) {
+	n := copy(p, r.data)
+	return n, nil
 }


### PR DESCRIPTION
Resolves #134

## Description
This PR replaces raw `panic()` calls in [readNonce()](cci:1://file:///c:/Users/Windows/Desktop/fabric-x/tools/fxconfig/internal/transaction/endorse.go:112:0-130:1) with proper error returns, ensuring that the application can gracefully handle random byte nonce generation failures instead of hard crashing. Errors are now bubbled up through the call stack.

## Changes Made
- **[tools/fxconfig/internal/transaction/endorse.go](cci:7://file:///c:/Users/Windows/Desktop/fabric-x/tools/fxconfig/internal/transaction/endorse.go:0:0-0:0)**:
  - Refactored [readNonce()](cci:1://file:///c:/Users/Windows/Desktop/fabric-x/tools/fxconfig/internal/transaction/endorse.go:112:0-130:1) to return [([]byte, error)](cci:1://file:///c:/Users/Windows/Desktop/fabric-x/tools/fxconfig/internal/transaction/endorse_test.go:253:0-255:1) and replaced panics with descriptive error formats.
  - Refactored [GenerateTxID()](cci:1://file:///c:/Users/Windows/Desktop/fabric-x/tools/fxconfig/internal/transaction/endorse.go:101:0-110:1) to return [(string, error)](cci:1://file:///c:/Users/Windows/Desktop/fabric-x/tools/fxconfig/internal/transaction/endorse_test.go:253:0-255:1) to propagate failures upstream.
- **[tools/fxconfig/internal/app/create.go](cci:7://file:///c:/Users/Windows/Desktop/fabric-x/tools/fxconfig/internal/app/create.go:0:0-0:0)**:
  - Updated [CreateNamespace()](cci:1://file:///c:/Users/Windows/Desktop/fabric-x/tools/fxconfig/internal/app/create.go:21:0-40:1) to handle the error return from `transaction.GenerateTxID()`.
- **[tools/fxconfig/internal/transaction/endorse_test.go](cci:7://file:///c:/Users/Windows/Desktop/fabric-x/tools/fxconfig/internal/transaction/endorse_test.go:0:0-0:0)**:
  - Refactored [TestGenerateTxID](cci:1://file:///c:/Users/Windows/Desktop/fabric-x/tools/fxconfig/internal/transaction/endorse_test.go:189:0-214:1) to accommodate the new return signature.
  - Added new test cases in [TestReadNonce](cci:1://file:///c:/Users/Windows/Desktop/fabric-x/tools/fxconfig/internal/transaction/endorse_test.go:216:0-246:1) simulating `io.Reader` failures, short reads, and valid responses to ensure complete logic coverage.

## Verification
- ✅ Ran unit tests `go test ./tools/fxconfig/internal/transaction/... -run "TestGenerateTxID|TestReadNonce"`
- ✅ Verify full module builds properly with `go build ./tools/fxconfig/...`
