### PR TITLE
Updated `Dockerfile` to use `golang:1.26` as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 ###########################################
 # Stage 1: Build image
 ###########################################
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 
 # Build environment variables
 ENV CGO_ENABLED=1


### PR DESCRIPTION
<!--
Copyright IBM Corp. All Rights Reserved.

SPDX-License-Identifier: Apache-2.0

DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST.

If this PR introduces a breaking change that affects compatibility with other components:
- The PR title must begin with the prefix [BREAKING].
- "Breaking change" must be included in the list below.
- Relevant stakeholders must be notified before or immediately after the PR is merged.
-->
#### Type of change

<!--- What type of change? Pick one or more options and delete the others. -->

- Improvement (improvement to code, performance, etc)

#### Description

<!--- Describe your changes in detail, including motivation. -->

The new `fabric-x-tools` require `go:1.26` to be built. This PR fixes the issue for the image build.
