### PR TITLE
fxconfig: clean up provider-managed grpc clients at app shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 
 # python
 .venv
+
+.codex

--- a/tools/fxconfig/internal/app/app.go
+++ b/tools/fxconfig/internal/app/app.go
@@ -10,6 +10,8 @@ package app
 
 import (
 	"context"
+	"errors"
+	"sync"
 
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/msp"
@@ -27,6 +29,7 @@ type Application interface {
 	SubmitTransaction(ctx context.Context, txID string, tx *applicationpb.Tx) error
 	SubmitTransactionWithWait(ctx context.Context, txID string, tx *applicationpb.Tx) (TxStatus, error)
 	MergeTransactions(ctx context.Context, txs []*applicationpb.Tx) (*applicationpb.Tx, error)
+	Close() error
 }
 
 // AdminApp implements Application interface with provider-based dependencies.
@@ -36,4 +39,30 @@ type AdminApp struct {
 	QueryProvider        *provider.Provider[adapters.QueryClient, *config.QueriesConfig]
 	OrdererProvider      *provider.Provider[adapters.OrdererClient, *config.OrdererConfig]
 	NotificationProvider *provider.Provider[adapters.NotificationClient, *config.NotificationsConfig]
+	closeOnce            sync.Once
+	closeErr             error
+}
+
+// Close releases provider-managed resources owned by the application.
+func (d *AdminApp) Close() error {
+	d.closeOnce.Do(func() {
+		var errs []error
+
+		if d.NotificationProvider != nil {
+			errs = append(errs, d.NotificationProvider.Close())
+		}
+		if d.OrdererProvider != nil {
+			errs = append(errs, d.OrdererProvider.Close())
+		}
+		if d.QueryProvider != nil {
+			errs = append(errs, d.QueryProvider.Close())
+		}
+		if d.MspProvider != nil {
+			errs = append(errs, d.MspProvider.Close())
+		}
+
+		d.closeErr = errors.Join(errs...)
+	})
+
+	return d.closeErr
 }

--- a/tools/fxconfig/internal/app/list.go
+++ b/tools/fxconfig/internal/app/list.go
@@ -20,9 +20,6 @@ func (d *AdminApp) ListNamespaces(ctx context.Context) ([]NamespaceQueryResult, 
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = qc.Close()
-	}()
 
 	res, err := qc.GetNamespacePolicies(ctx)
 	if err != nil {

--- a/tools/fxconfig/internal/app/list_test.go
+++ b/tools/fxconfig/internal/app/list_test.go
@@ -21,15 +21,24 @@ import (
 )
 
 type mockQueryClient struct {
-	policies *applicationpb.NamespacePolicies
-	err      error
+	policies   *applicationpb.NamespacePolicies
+	err        error
+	closed     bool
+	closeCalls int
 }
 
 func (m *mockQueryClient) GetNamespacePolicies(_ context.Context) (*applicationpb.NamespacePolicies, error) {
+	if m.closed {
+		return nil, errors.New("query client closed")
+	}
 	return m.policies, m.err
 }
 
-func (*mockQueryClient) Close() error { return nil }
+func (m *mockQueryClient) Close() error {
+	m.closed = true
+	m.closeCalls++
+	return nil
+}
 
 func makeQueryProvider(
 	client adapters.QueryClient,
@@ -44,6 +53,18 @@ func makeQueryProvider(
 	return provider.New(func(_ *config.QueriesConfig) (adapters.QueryClient, error) {
 		return client, err
 	}, cfg, fakeValidationContext())
+}
+
+func makeManagedQueryProvider(
+	factory func(*config.QueriesConfig) (adapters.QueryClient, error),
+) *provider.Provider[adapters.QueryClient, *config.QueriesConfig] {
+	cfg := &config.QueriesConfig{
+		EndpointServiceConfig: config.EndpointServiceConfig{
+			Address:           "localhost:7050",
+			ConnectionTimeout: 30 * time.Second,
+		},
+	}
+	return provider.New(factory, cfg, fakeValidationContext())
 }
 
 func TestListNamespaces_Empty(t *testing.T) {
@@ -89,4 +110,22 @@ func TestListNamespaces_QueryError(t *testing.T) {
 
 	_, err := a.ListNamespaces(t.Context())
 	require.Error(t, err)
+}
+
+func TestListNamespaces_ReusesProviderManagedQueryClient(t *testing.T) {
+	t.Parallel()
+
+	client := &mockQueryClient{policies: &applicationpb.NamespacePolicies{}}
+	a := &AdminApp{
+		QueryProvider: makeManagedQueryProvider(func(_ *config.QueriesConfig) (adapters.QueryClient, error) {
+			return client, nil
+		}),
+	}
+
+	_, err := a.ListNamespaces(t.Context())
+	require.NoError(t, err)
+
+	_, err = a.ListNamespaces(t.Context())
+	require.NoError(t, err)
+	require.False(t, client.closed)
 }

--- a/tools/fxconfig/internal/app/submit.go
+++ b/tools/fxconfig/internal/app/submit.go
@@ -28,9 +28,6 @@ func (d *AdminApp) SubmitTransaction(ctx context.Context, txID string, tx *appli
 	if err != nil {
 		return fmt.Errorf("failed to prepare submission: %w", err)
 	}
-	defer func() {
-		_ = sc.ordererClient.Close()
-	}()
 
 	if err := sc.ordererClient.Broadcast(ctx, sc.signingIdentity, txID, tx); err != nil {
 		return fmt.Errorf("failed to broadcast transaction: %w", err)
@@ -46,19 +43,12 @@ func (d *AdminApp) SubmitTransactionWithWait(ctx context.Context, txID string, t
 	if err != nil {
 		return UnknownStatus, fmt.Errorf("failed to prepare submission: %w", err)
 	}
-	defer func() {
-		_ = sc.ordererClient.Close()
-	}()
 
 	// get notification client
 	nc, err := d.NotificationProvider.Get()
 	if err != nil {
 		return UnknownStatus, fmt.Errorf("failed to get notification client: %w", err)
 	}
-
-	defer func() {
-		_ = nc.Close()
-	}()
 
 	subscription, err := nc.Subscribe(ctx, txID)
 	if err != nil {

--- a/tools/fxconfig/internal/app/submit_test.go
+++ b/tools/fxconfig/internal/app/submit_test.go
@@ -23,21 +23,35 @@ import (
 
 type mockOrdererClient struct {
 	broadcastErr error
+	closed       bool
+	closeCalls   int
 }
 
 func (m *mockOrdererClient) Broadcast(_ context.Context, _ msp.SigningIdentity, _ string, _ *applicationpb.Tx) error {
+	if m.closed {
+		return errors.New("orderer client closed")
+	}
 	return m.broadcastErr
 }
 
-func (*mockOrdererClient) Close() error { return nil }
+func (m *mockOrdererClient) Close() error {
+	m.closed = true
+	m.closeCalls++
+	return nil
+}
 
 type mockNotificationClient struct {
 	subscribeErr error
 	waitErr      error
 	status       int
+	closed       bool
+	closeCalls   int
 }
 
 func (m *mockNotificationClient) Subscribe(_ context.Context, _ string) (chan int, error) {
+	if m.closed {
+		return nil, errors.New("notification client closed")
+	}
 	if m.subscribeErr != nil {
 		return nil, m.subscribeErr
 	}
@@ -47,13 +61,20 @@ func (m *mockNotificationClient) Subscribe(_ context.Context, _ string) (chan in
 }
 
 func (m *mockNotificationClient) WaitForEvent(_ context.Context, ch chan int) (int, error) {
+	if m.closed {
+		return 0, errors.New("notification client closed")
+	}
 	if m.waitErr != nil {
 		return 0, m.waitErr
 	}
 	return <-ch, nil
 }
 
-func (*mockNotificationClient) Close() error { return nil }
+func (m *mockNotificationClient) Close() error {
+	m.closed = true
+	m.closeCalls++
+	return nil
+}
 
 func makeOrdererProvider(
 	client adapters.OrdererClient,
@@ -71,6 +92,19 @@ func makeOrdererProvider(
 	}, cfg, fakeValidationContext())
 }
 
+func makeManagedOrdererProvider(
+	factory func(*config.OrdererConfig) (adapters.OrdererClient, error),
+) *provider.Provider[adapters.OrdererClient, *config.OrdererConfig] {
+	cfg := &config.OrdererConfig{
+		EndpointServiceConfig: config.EndpointServiceConfig{
+			Address:           "localhost:7050",
+			ConnectionTimeout: 30 * time.Second,
+		},
+		Channel: "mychannel",
+	}
+	return provider.New(factory, cfg, fakeValidationContext())
+}
+
 func makeNotificationProvider(
 	client adapters.NotificationClient,
 	err error,
@@ -84,6 +118,18 @@ func makeNotificationProvider(
 	return provider.New(func(_ *config.NotificationsConfig) (adapters.NotificationClient, error) {
 		return client, err
 	}, cfg, fakeValidationContext())
+}
+
+func makeManagedNotificationProvider(
+	factory func(*config.NotificationsConfig) (adapters.NotificationClient, error),
+) *provider.Provider[adapters.NotificationClient, *config.NotificationsConfig] {
+	cfg := &config.NotificationsConfig{
+		EndpointServiceConfig: config.EndpointServiceConfig{
+			Address:           "localhost:9000",
+			ConnectionTimeout: 30 * time.Second,
+		},
+	}
+	return provider.New(factory, cfg, fakeValidationContext())
 }
 
 func someTx() *applicationpb.Tx {
@@ -247,4 +293,117 @@ func TestSubmitTransactionWithWait_Success(t *testing.T) {
 	status, err := a.SubmitTransactionWithWait(t.Context(), "tx-1", someTx())
 	require.NoError(t, err)
 	require.Equal(t, expectedStatus, status)
+}
+
+func TestSubmitTransaction_ReusesProviderManagedOrdererClient(t *testing.T) {
+	t.Parallel()
+
+	client := &mockOrdererClient{}
+	a := &AdminApp{
+		MspProvider: makeMSPProvider(&testSigningIdentity{}, nil),
+		OrdererProvider: makeManagedOrdererProvider(func(_ *config.OrdererConfig) (adapters.OrdererClient, error) {
+			return client, nil
+		}),
+	}
+
+	err := a.SubmitTransaction(t.Context(), "tx-1", someTx())
+	require.NoError(t, err)
+
+	err = a.SubmitTransaction(t.Context(), "tx-2", someTx())
+	require.NoError(t, err)
+	require.False(t, client.closed)
+}
+
+func TestSubmitTransactionWithWait_ReusesProviderManagedClients(t *testing.T) {
+	t.Parallel()
+
+	ordererClient := &mockOrdererClient{}
+	notificationClient := &mockNotificationClient{status: 7}
+
+	a := &AdminApp{
+		MspProvider: makeMSPProvider(&testSigningIdentity{}, nil),
+		OrdererProvider: makeManagedOrdererProvider(func(_ *config.OrdererConfig) (adapters.OrdererClient, error) {
+			return ordererClient, nil
+		}),
+		NotificationProvider: makeManagedNotificationProvider(
+			func(_ *config.NotificationsConfig) (adapters.NotificationClient, error) {
+				return notificationClient, nil
+			},
+		),
+	}
+
+	status, err := a.SubmitTransactionWithWait(t.Context(), "tx-1", someTx())
+	require.NoError(t, err)
+	require.Equal(t, 7, status)
+
+	status, err = a.SubmitTransactionWithWait(t.Context(), "tx-2", someTx())
+	require.NoError(t, err)
+	require.Equal(t, 7, status)
+	require.False(t, ordererClient.closed)
+	require.False(t, notificationClient.closed)
+}
+
+func TestAdminApp_Close_ClosesProviderManagedClients(t *testing.T) {
+	t.Parallel()
+
+	ordererClient := &mockOrdererClient{}
+	notificationClient := &mockNotificationClient{}
+	queryClient := &mockQueryClient{policies: &applicationpb.NamespacePolicies{}}
+
+	a := &AdminApp{
+		MspProvider: makeMSPProvider(&testSigningIdentity{}, nil),
+		OrdererProvider: makeManagedOrdererProvider(func(_ *config.OrdererConfig) (adapters.OrdererClient, error) {
+			return ordererClient, nil
+		}),
+		NotificationProvider: makeManagedNotificationProvider(
+			func(_ *config.NotificationsConfig) (adapters.NotificationClient, error) {
+				return notificationClient, nil
+			},
+		),
+		QueryProvider: makeQueryProvider(queryClient, nil),
+	}
+
+	require.NoError(t, a.SubmitTransaction(t.Context(), "tx-1", someTx()))
+	_, err := a.SubmitTransactionWithWait(t.Context(), "tx-2", someTx())
+	require.NoError(t, err)
+	_, err = a.ListNamespaces(t.Context())
+	require.NoError(t, err)
+
+	require.NoError(t, a.Close())
+	require.True(t, ordererClient.closed)
+	require.True(t, notificationClient.closed)
+	require.True(t, queryClient.closed)
+}
+
+func TestAdminApp_Close_IsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	ordererClient := &mockOrdererClient{}
+	notificationClient := &mockNotificationClient{}
+	queryClient := &mockQueryClient{policies: &applicationpb.NamespacePolicies{}}
+
+	a := &AdminApp{
+		MspProvider: makeMSPProvider(&testSigningIdentity{}, nil),
+		OrdererProvider: makeManagedOrdererProvider(func(_ *config.OrdererConfig) (adapters.OrdererClient, error) {
+			return ordererClient, nil
+		}),
+		NotificationProvider: makeManagedNotificationProvider(
+			func(_ *config.NotificationsConfig) (adapters.NotificationClient, error) {
+				return notificationClient, nil
+			},
+		),
+		QueryProvider: makeQueryProvider(queryClient, nil),
+	}
+
+	require.NoError(t, a.SubmitTransaction(t.Context(), "tx-1", someTx()))
+	_, err := a.SubmitTransactionWithWait(t.Context(), "tx-2", someTx())
+	require.NoError(t, err)
+	_, err = a.ListNamespaces(t.Context())
+	require.NoError(t, err)
+
+	require.NoError(t, a.Close())
+	require.NoError(t, a.Close())
+	require.Equal(t, 1, ordererClient.closeCalls)
+	require.Equal(t, 1, notificationClient.closeCalls)
+	require.Equal(t, 1, queryClient.closeCalls)
 }

--- a/tools/fxconfig/internal/cli/v1/namespace_create_test.go
+++ b/tools/fxconfig/internal/cli/v1/namespace_create_test.go
@@ -141,3 +141,13 @@ func (t *testApp) SubmitTransactionWithWait(
 	args := t.Called(ctx, txID, tx)
 	return args.Int(0), args.Error(1)
 }
+
+func (t *testApp) Close() error {
+	for _, call := range t.ExpectedCalls {
+		if call.Method == "Close" {
+			args := t.Called()
+			return args.Error(0)
+		}
+	}
+	return nil
+}

--- a/tools/fxconfig/internal/provider/provider.go
+++ b/tools/fxconfig/internal/provider/provider.go
@@ -21,6 +21,8 @@ type Provider[T any, K Validatable] struct {
 	instance          T
 	err               error
 	cfg               K
+	initialized       bool
+	ready             bool
 	validationContext validation.Context
 }
 
@@ -42,18 +44,37 @@ func New[T any, K Validatable](
 // Subsequent calls return the cached instance. Thread-safe.
 func (p *Provider[T, K]) Get() (T, error) {
 	p.once.Do(func() {
+		p.initialized = true
 		if err := p.cfg.Validate(p.validationContext); err != nil {
 			p.err = err
 			return
 		}
+
 		p.instance, p.err = p.factory(p.cfg)
+		p.ready = p.err == nil
 	})
+
 	return p.instance, p.err
 }
 
 // Validate delegates to the configuration's Validate method.
 func (p *Provider[T, K]) Validate() error {
 	return p.cfg.Validate(p.validationContext)
+}
+
+// Close releases the cached instance if it was initialized successfully and
+// implements a Close() error method. Non-closeable instances are ignored.
+func (p *Provider[T, K]) Close() error {
+	if !p.initialized || !p.ready {
+		return nil
+	}
+
+	closer, ok := any(p.instance).(interface{ Close() error })
+	if !ok {
+		return nil
+	}
+
+	return closer.Close()
 }
 
 // Validatable defines the interface for configuration types that can be validated.

--- a/tools/fxconfig/internal/provider/provider_test.go
+++ b/tools/fxconfig/internal/provider/provider_test.go
@@ -190,3 +190,52 @@ func TestProvider_Validate_Error(t *testing.T) {
 	err := p.Validate()
 	require.ErrorIs(t, err, expectedErr)
 }
+
+type closeableMockService struct {
+	closeErr   error
+	closeCalls int
+}
+
+func (m *closeableMockService) Close() error {
+	m.closeCalls++
+	return m.closeErr
+}
+
+func TestProvider_Close_NoOpBeforeGet(t *testing.T) {
+	t.Parallel()
+
+	cfg := &mockConfig{}
+	p := provider.New(func(*mockConfig) (*closeableMockService, error) {
+		return &closeableMockService{}, nil
+	}, cfg, validation.Context{})
+
+	require.NoError(t, p.Close())
+}
+
+func TestProvider_Close_ClosesCachedInstance(t *testing.T) {
+	t.Parallel()
+
+	expected := &closeableMockService{}
+	cfg := &mockConfig{}
+	p := provider.New(func(*mockConfig) (*closeableMockService, error) {
+		return expected, nil
+	}, cfg, validation.Context{})
+
+	_, err := p.Get()
+	require.NoError(t, err)
+	require.NoError(t, p.Close())
+	require.Equal(t, 1, expected.closeCalls)
+}
+
+func TestProvider_Close_IgnoresFailedInitialization(t *testing.T) {
+	t.Parallel()
+
+	cfg := &mockConfig{validateErr: errors.New("validation error")}
+	p := provider.New(func(*mockConfig) (*closeableMockService, error) {
+		return &closeableMockService{}, nil
+	}, cfg, validation.Context{})
+
+	_, err := p.Get()
+	require.Error(t, err)
+	require.NoError(t, p.Close())
+}

--- a/tools/fxconfig/main.go
+++ b/tools/fxconfig/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/signal"
 
@@ -74,5 +75,10 @@ func run() error {
 		},
 	)
 
-	return cmd.ExecuteContext(ctx)
+	err := cmd.ExecuteContext(ctx)
+	if cliCtx.App != nil {
+		err = errors.Join(err, cliCtx.App.Close())
+	}
+
+	return err
 }


### PR DESCRIPTION
#### Type of change

- Bug fix


#### Description

This PR fixes grpc client lifecycle ownership in `fxconfig`.

Currently, `fxconfig` caches grpc clients through providers, but some app-layer operations close those clients after use. In particular, the submission and query paths treat provider-managed clients as per-operation resources, which creates an ownership mismatch between the provider layer and its consumers.

This change keeps the existing provider-based caching model intact and moves cleanup responsibility to application shutdown instead.

The main changes are:

- add `Close()` to the `app.Application` interface
- implement `AdminApp.Close()` to release provider-managed resources
- add `Provider.Close()` to close cached instances that implement `Close()`
- remove per-operation `Close()` calls from:
  - `tools/fxconfig/internal/app/submit.go`
  - `tools/fxconfig/internal/app/list.go`
- update `main.run()` so the CLI closes the application once command execution completes

This makes lifecycle ownership explicit:

- providers own cached grpc clients
- app operations use them without closing them
- the CLI triggers shutdown once and cleanup happens there

This follows the existing architecture more closely and avoids ambiguity around resource ownership.

#### Additional details (Optional)

Regression coverage was added for:

- repeated submit operations using provider-managed orderer clients
- repeated `--wait` operations using provider-managed orderer and notification clients
- repeated query operations using provider-managed query clients
- cleanup of cached clients during app shutdown
- provider cleanup behavior for initialized and uninitialized instances

Validation performed:

```bash
go test -v ./tools/fxconfig/internal/provider ./tools/fxconfig/internal/app ./tools/fxconfig/internal/cli/v1
```

Also checked:
```bash
git diff --check
```
A full go test ./tools/fxconfig/... run is currently blocked in my local environment by missing integration fixtures:

tools/fxconfig/integration/testdata/crypto/single-org.pb.bin
tools/fxconfig/integration/testdata/crypto/multi-org.pb.bin

Related issues
Closes #116 