### PR TITLE
fix(tokens): make teardown-fabric idempotent when fabric_test network is absent

### DIFF
--- a/samples/tokens/fabricx_dev.mk
+++ b/samples/tokens/fabricx_dev.mk
@@ -47,7 +47,7 @@ stop-fabric:
 # Teardown fabric-x
 .PHONY: teardown-fabric
 teardown-fabric: stop-fabric
-	@$(CONTAINER_CLI) network inspect fabric_test >/dev/null 2>&1 && $(CONTAINER_CLI) network rm fabric_test
+	@$(CONTAINER_CLI) network rm fabric_test >/dev/null 2>&1 || echo "Warning: Docker network 'fabric_test' not found or already removed."
 
 
 # Restart fabric. This deletes the ledger; the app must be cleaned as well.


### PR DESCRIPTION
#### Type of change

- Bug fix hyperledger/fabric-x-samples#10 

#### Description

`teardown-fabric` in `samples/tokens/fabricx_dev.mk` used an `inspect && rm` chain
to remove the `fabric_test` Docker network:

```makefile
# Before
@$(CONTAINER_CLI) network inspect fabric_test >/dev/null 2>&1 && $(CONTAINER_CLI) network rm fabric_test
When fabric_test is already absent, network inspect exits non-zero, causing
network rm to be skipped and the Make target to exit 1 — even though the
environment is already clean. This breaks repeated make setup/make teardown
cycles in both local development and CI.

Fix replaces the chain with an unconditional remove and a warning fallback:
# After
@$(CONTAINER_CLI) network rm fabric_test >/dev/null 2>&1 || echo "Warning: Docker network 'fabric_test' not found or already removed."
This makes teardown-fabric idempotent: it exits 0 whether or not the network
exists, consistent with how stop-fabric already handles missing containers
via docker compose down.

Additional details (Optional)
1 line changed in samples/tokens/fabricx_dev.mk

Compatible with both docker and podman (CONTAINER_CLI variable)

No behaviour change when fabric_test exists — network is still removed normally

Related issues


Fixes hyperledger/fabric-x-samples#10