### PR TITLE
bug(tokens/issuer): fix nil return in IssueCashView.Call() on ordering failure

### DIFF
--- a/samples/tokens/issuer/service/fsc.go
+++ b/samples/tokens/issuer/service/fsc.go
@@ -156,7 +156,7 @@ func (v *IssueCashView) Call(vctx view.Context) (interface{}, error) {
 	logger.Infof("submitting fabric transaction to orderer for final settlemement: [%s]", tx.ID())
 	_, err = vctx.RunView(ttx.NewOrderingAndFinalityView(tx))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed asking ordering")
+		return "", errors.Wrap(err, "failed asking ordering")
 	}
 
 	return tx.ID(), nil


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

In `IssueCashView.Call()` (`samples/tokens/issuer/service/fsc.go`), the error
return path after a failed `NewOrderingAndFinalityView` call incorrectly returns
`nil` as the first value instead of `""` (empty string).

**Root cause:**

The function signature is `Call(vctx view.Context) (interface{}, error)`.
Every other early-return error path in this function returns `""` as the first
value. However, the ordering failure path returned `nil`:

```go
// Before (buggy)
return nil, errors.Wrap(err, "failed asking ordering")
```

**Impact:**

The caller `Issue()` performs a type assertion on the returned value:

```go
txID, ok := res.(string)
if !ok {
    return "", errors.New("cannot parse issue response")
}
```

When `res` is `nil`, the type assertion `res.(string)` silently evaluates to
`ok = false`. This causes two problems:
1. The **real ordering error is completely lost** — it was already returned via
   the `error` channel and logged, but the caller discards it and replaces it
   with the misleading `"cannot parse issue response"` message.
2. Debugging ordering failures becomes significantly harder because the actual
   error message (e.g., TLS failure, timeout, MVCC conflict) is masked.

**Fix:**

```go
// After (fixed)
return "", errors.Wrap(err, "failed asking ordering")
```

This makes the return consistent with all other error paths in the function and
ensures the real error propagates correctly to the HTTP layer.

#### Additional details (Optional)

The fix is a single-character change on one line. No tests, config changes, or
interface changes are required. The fix was verified by tracing the full call
chain: `IssueCashView.Call()` → `mgr.InitiateView()` → `Issue()` →
`routes.Issue()` → HTTP 500 response.

A demo reproducing the silent failure before the fix:

```go
var res interface{} = nil        // simulates old buggy return
txID, ok := res.(string)
fmt.Println("ok:", ok)           // → false
fmt.Println("txID:", txID)       // → ""
// real error is gone; caller sees "cannot parse issue response"
```

#### Related issues

Fixes hyperledger/fabric-x-samples#12