### PR TITLE
fxconfig: fail fast when notification stream startup fails

### DIFF
--- a/tools/fxconfig/internal/app/app.go
+++ b/tools/fxconfig/internal/app/app.go
@@ -10,6 +10,7 @@ package app
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/msp"
@@ -27,6 +28,7 @@ type Application interface {
 	SubmitTransaction(ctx context.Context, txID string, tx *applicationpb.Tx) error
 	SubmitTransactionWithWait(ctx context.Context, txID string, tx *applicationpb.Tx) (TxStatus, error)
 	MergeTransactions(ctx context.Context, txs []*applicationpb.Tx) (*applicationpb.Tx, error)
+	Close() error
 }
 
 // AdminApp implements Application interface with provider-based dependencies.
@@ -36,4 +38,24 @@ type AdminApp struct {
 	QueryProvider        *provider.Provider[adapters.QueryClient, *config.QueriesConfig]
 	OrdererProvider      *provider.Provider[adapters.OrdererClient, *config.OrdererConfig]
 	NotificationProvider *provider.Provider[adapters.NotificationClient, *config.NotificationsConfig]
+}
+
+// Close releases provider-managed resources owned by the application.
+func (d *AdminApp) Close() error {
+	var errs []error
+
+	if d.NotificationProvider != nil {
+		errs = append(errs, d.NotificationProvider.Close())
+	}
+	if d.OrdererProvider != nil {
+		errs = append(errs, d.OrdererProvider.Close())
+	}
+	if d.QueryProvider != nil {
+		errs = append(errs, d.QueryProvider.Close())
+	}
+	if d.MspProvider != nil {
+		errs = append(errs, d.MspProvider.Close())
+	}
+
+	return errors.Join(errs...)
 }

--- a/tools/fxconfig/internal/app/list.go
+++ b/tools/fxconfig/internal/app/list.go
@@ -20,9 +20,6 @@ func (d *AdminApp) ListNamespaces(ctx context.Context) ([]NamespaceQueryResult, 
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = qc.Close()
-	}()
 
 	res, err := qc.GetNamespacePolicies(ctx)
 	if err != nil {

--- a/tools/fxconfig/internal/app/list_test.go
+++ b/tools/fxconfig/internal/app/list_test.go
@@ -23,13 +23,20 @@ import (
 type mockQueryClient struct {
 	policies *applicationpb.NamespacePolicies
 	err      error
+	closed   bool
 }
 
 func (m *mockQueryClient) GetNamespacePolicies(_ context.Context) (*applicationpb.NamespacePolicies, error) {
+	if m.closed {
+		return nil, errors.New("query client closed")
+	}
 	return m.policies, m.err
 }
 
-func (*mockQueryClient) Close() error { return nil }
+func (m *mockQueryClient) Close() error {
+	m.closed = true
+	return nil
+}
 
 func makeQueryProvider(
 	client adapters.QueryClient,
@@ -44,6 +51,18 @@ func makeQueryProvider(
 	return provider.New(func(_ *config.QueriesConfig) (adapters.QueryClient, error) {
 		return client, err
 	}, cfg, fakeValidationContext())
+}
+
+func makeManagedQueryProvider(
+	factory func(*config.QueriesConfig) (adapters.QueryClient, error),
+) *provider.Provider[adapters.QueryClient, *config.QueriesConfig] {
+	cfg := &config.QueriesConfig{
+		EndpointServiceConfig: config.EndpointServiceConfig{
+			Address:           "localhost:7050",
+			ConnectionTimeout: 30 * time.Second,
+		},
+	}
+	return provider.New(factory, cfg, fakeValidationContext())
 }
 
 func TestListNamespaces_Empty(t *testing.T) {
@@ -89,4 +108,22 @@ func TestListNamespaces_QueryError(t *testing.T) {
 
 	_, err := a.ListNamespaces(t.Context())
 	require.Error(t, err)
+}
+
+func TestListNamespaces_ReusesProviderManagedQueryClient(t *testing.T) {
+	t.Parallel()
+
+	client := &mockQueryClient{policies: &applicationpb.NamespacePolicies{}}
+	a := &AdminApp{
+		QueryProvider: makeManagedQueryProvider(func(_ *config.QueriesConfig) (adapters.QueryClient, error) {
+			return client, nil
+		}),
+	}
+
+	_, err := a.ListNamespaces(t.Context())
+	require.NoError(t, err)
+
+	_, err = a.ListNamespaces(t.Context())
+	require.NoError(t, err)
+	require.False(t, client.closed)
 }

--- a/tools/fxconfig/internal/app/submit.go
+++ b/tools/fxconfig/internal/app/submit.go
@@ -28,9 +28,6 @@ func (d *AdminApp) SubmitTransaction(ctx context.Context, txID string, tx *appli
 	if err != nil {
 		return fmt.Errorf("failed to prepare submission: %w", err)
 	}
-	defer func() {
-		_ = sc.ordererClient.Close()
-	}()
 
 	if err := sc.ordererClient.Broadcast(ctx, sc.signingIdentity, txID, tx); err != nil {
 		return fmt.Errorf("failed to broadcast transaction: %w", err)
@@ -46,19 +43,12 @@ func (d *AdminApp) SubmitTransactionWithWait(ctx context.Context, txID string, t
 	if err != nil {
 		return UnknownStatus, fmt.Errorf("failed to prepare submission: %w", err)
 	}
-	defer func() {
-		_ = sc.ordererClient.Close()
-	}()
 
 	// get notification client
 	nc, err := d.NotificationProvider.Get()
 	if err != nil {
 		return UnknownStatus, fmt.Errorf("failed to get notification client: %w", err)
 	}
-
-	defer func() {
-		_ = nc.Close()
-	}()
 
 	subscription, err := nc.Subscribe(ctx, txID)
 	if err != nil {

--- a/tools/fxconfig/internal/app/submit_test.go
+++ b/tools/fxconfig/internal/app/submit_test.go
@@ -23,21 +23,32 @@ import (
 
 type mockOrdererClient struct {
 	broadcastErr error
+	closed       bool
 }
 
 func (m *mockOrdererClient) Broadcast(_ context.Context, _ msp.SigningIdentity, _ string, _ *applicationpb.Tx) error {
+	if m.closed {
+		return errors.New("orderer client closed")
+	}
 	return m.broadcastErr
 }
 
-func (*mockOrdererClient) Close() error { return nil }
+func (m *mockOrdererClient) Close() error {
+	m.closed = true
+	return nil
+}
 
 type mockNotificationClient struct {
 	subscribeErr error
 	waitErr      error
 	status       int
+	closed       bool
 }
 
 func (m *mockNotificationClient) Subscribe(_ context.Context, _ string) (chan int, error) {
+	if m.closed {
+		return nil, errors.New("notification client closed")
+	}
 	if m.subscribeErr != nil {
 		return nil, m.subscribeErr
 	}
@@ -47,13 +58,19 @@ func (m *mockNotificationClient) Subscribe(_ context.Context, _ string) (chan in
 }
 
 func (m *mockNotificationClient) WaitForEvent(_ context.Context, ch chan int) (int, error) {
+	if m.closed {
+		return 0, errors.New("notification client closed")
+	}
 	if m.waitErr != nil {
 		return 0, m.waitErr
 	}
 	return <-ch, nil
 }
 
-func (*mockNotificationClient) Close() error { return nil }
+func (m *mockNotificationClient) Close() error {
+	m.closed = true
+	return nil
+}
 
 func makeOrdererProvider(
 	client adapters.OrdererClient,
@@ -71,6 +88,19 @@ func makeOrdererProvider(
 	}, cfg, fakeValidationContext())
 }
 
+func makeManagedOrdererProvider(
+	factory func(*config.OrdererConfig) (adapters.OrdererClient, error),
+) *provider.Provider[adapters.OrdererClient, *config.OrdererConfig] {
+	cfg := &config.OrdererConfig{
+		EndpointServiceConfig: config.EndpointServiceConfig{
+			Address:           "localhost:7050",
+			ConnectionTimeout: 30 * time.Second,
+		},
+		Channel: "mychannel",
+	}
+	return provider.New(factory, cfg, fakeValidationContext())
+}
+
 func makeNotificationProvider(
 	client adapters.NotificationClient,
 	err error,
@@ -84,6 +114,18 @@ func makeNotificationProvider(
 	return provider.New(func(_ *config.NotificationsConfig) (adapters.NotificationClient, error) {
 		return client, err
 	}, cfg, fakeValidationContext())
+}
+
+func makeManagedNotificationProvider(
+	factory func(*config.NotificationsConfig) (adapters.NotificationClient, error),
+) *provider.Provider[adapters.NotificationClient, *config.NotificationsConfig] {
+	cfg := &config.NotificationsConfig{
+		EndpointServiceConfig: config.EndpointServiceConfig{
+			Address:           "localhost:9000",
+			ConnectionTimeout: 30 * time.Second,
+		},
+	}
+	return provider.New(factory, cfg, fakeValidationContext())
 }
 
 func someTx() *applicationpb.Tx {
@@ -247,4 +289,84 @@ func TestSubmitTransactionWithWait_Success(t *testing.T) {
 	status, err := a.SubmitTransactionWithWait(t.Context(), "tx-1", someTx())
 	require.NoError(t, err)
 	require.Equal(t, expectedStatus, status)
+}
+
+func TestSubmitTransaction_ReusesProviderManagedOrdererClient(t *testing.T) {
+	t.Parallel()
+
+	client := &mockOrdererClient{}
+	a := &AdminApp{
+		MspProvider: makeMSPProvider(&testSigningIdentity{}, nil),
+		OrdererProvider: makeManagedOrdererProvider(func(_ *config.OrdererConfig) (adapters.OrdererClient, error) {
+			return client, nil
+		}),
+	}
+
+	err := a.SubmitTransaction(t.Context(), "tx-1", someTx())
+	require.NoError(t, err)
+
+	err = a.SubmitTransaction(t.Context(), "tx-2", someTx())
+	require.NoError(t, err)
+	require.False(t, client.closed)
+}
+
+func TestSubmitTransactionWithWait_ReusesProviderManagedClients(t *testing.T) {
+	t.Parallel()
+
+	ordererClient := &mockOrdererClient{}
+	notificationClient := &mockNotificationClient{status: 7}
+
+	a := &AdminApp{
+		MspProvider: makeMSPProvider(&testSigningIdentity{}, nil),
+		OrdererProvider: makeManagedOrdererProvider(func(_ *config.OrdererConfig) (adapters.OrdererClient, error) {
+			return ordererClient, nil
+		}),
+		NotificationProvider: makeManagedNotificationProvider(
+			func(_ *config.NotificationsConfig) (adapters.NotificationClient, error) {
+				return notificationClient, nil
+			},
+		),
+	}
+
+	status, err := a.SubmitTransactionWithWait(t.Context(), "tx-1", someTx())
+	require.NoError(t, err)
+	require.Equal(t, 7, status)
+
+	status, err = a.SubmitTransactionWithWait(t.Context(), "tx-2", someTx())
+	require.NoError(t, err)
+	require.Equal(t, 7, status)
+	require.False(t, ordererClient.closed)
+	require.False(t, notificationClient.closed)
+}
+
+func TestAdminApp_Close_ClosesProviderManagedClients(t *testing.T) {
+	t.Parallel()
+
+	ordererClient := &mockOrdererClient{}
+	notificationClient := &mockNotificationClient{}
+	queryClient := &mockQueryClient{policies: &applicationpb.NamespacePolicies{}}
+
+	a := &AdminApp{
+		MspProvider: makeMSPProvider(&testSigningIdentity{}, nil),
+		OrdererProvider: makeManagedOrdererProvider(func(_ *config.OrdererConfig) (adapters.OrdererClient, error) {
+			return ordererClient, nil
+		}),
+		NotificationProvider: makeManagedNotificationProvider(
+			func(_ *config.NotificationsConfig) (adapters.NotificationClient, error) {
+				return notificationClient, nil
+			},
+		),
+		QueryProvider: makeQueryProvider(queryClient, nil),
+	}
+
+	require.NoError(t, a.SubmitTransaction(t.Context(), "tx-1", someTx()))
+	_, err := a.SubmitTransactionWithWait(t.Context(), "tx-2", someTx())
+	require.NoError(t, err)
+	_, err = a.ListNamespaces(t.Context())
+	require.NoError(t, err)
+
+	require.NoError(t, a.Close())
+	require.True(t, ordererClient.closed)
+	require.True(t, notificationClient.closed)
+	require.True(t, queryClient.closed)
 }

--- a/tools/fxconfig/internal/cli/v1/namespace_create_test.go
+++ b/tools/fxconfig/internal/cli/v1/namespace_create_test.go
@@ -141,3 +141,13 @@ func (t *testApp) SubmitTransactionWithWait(
 	args := t.Called(ctx, txID, tx)
 	return args.Int(0), args.Error(1)
 }
+
+func (t *testApp) Close() error {
+	for _, call := range t.ExpectedCalls {
+		if call.Method == "Close" {
+			args := t.Called()
+			return args.Error(0)
+		}
+	}
+	return nil
+}

--- a/tools/fxconfig/internal/client/notifications.go
+++ b/tools/fxconfig/internal/client/notifications.go
@@ -49,25 +49,52 @@ func NewNotificationClient(cfg config.NotificationsConfig) (*NotificationClient,
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	nc, err := newNotificationClient(ctx, cfg, committerpb.NewNotifierClient(conn), func() {
+		cancel()
+		_ = conn.Close()
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return nc, nil
+}
+
+func newNotificationClient(
+	ctx context.Context,
+	cfg config.NotificationsConfig,
+	notifyClient committerpb.NotifierClient,
+	closeF func(),
+) (*NotificationClient, error) {
 	nc := &NotificationClient{
-		cfg:          cfg,
-		notifyClient: committerpb.NewNotifierClient(conn),
-		closeF: func() {
-			cancel()
-			_ = conn.Close()
-		},
+		cfg:           cfg,
+		notifyClient:  notifyClient,
+		closeF:        closeF,
 		requestQueue:  make(chan *committerpb.NotificationRequest),
 		responseQueue: make(chan *committerpb.NotificationResponse),
 		subscribers:   make(map[string][]chan int),
 	}
 
+	if err := nc.start(ctx); err != nil {
+		if nc.closeF != nil {
+			nc.closeF()
+		}
+		return nil, fmt.Errorf("failed to establish notification stream: %w", err)
+	}
+
+	return nc, nil
+}
+
+func (n *NotificationClient) start(ctx context.Context) error {
+	started := make(chan error, 1)
+
 	go func() {
-		if err := nc.listen(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		if err := n.listen(ctx, started); err != nil && !errors.Is(err, context.Canceled) {
 			logger.Errorf("Notification listener stream terminated unexpectedly: %s", err)
 		}
 	}()
 
-	return nc, nil
+	return <-started
 }
 
 // Close terminates the gRPC connection and cancels the background listener.
@@ -156,12 +183,14 @@ func wait(ctx context.Context, subscription chan int) (int, error) {
 // and dispatching notifications to subscribers. Blocks until context is canceled.
 //
 //nolint:gocognit
-func (n *NotificationClient) listen(ctx context.Context) error {
+func (n *NotificationClient) listen(ctx context.Context, started chan<- error) error {
 	notifyStream, err := n.notifyClient.OpenNotificationStream(ctx)
 	if err != nil {
 		n.streamErr.Store(&err)
+		started <- err
 		return err
 	}
+	started <- nil
 
 	// Use the base context for errgroup
 	g, gCtx := errgroup.WithContext(ctx)

--- a/tools/fxconfig/internal/client/notifications_test.go
+++ b/tools/fxconfig/internal/client/notifications_test.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/config"
@@ -27,6 +29,35 @@ func newTestNotificationClient(waitingTimeout time.Duration) *NotificationClient
 		responseQueue: make(chan *committerpb.NotificationResponse),
 		subscribers:   make(map[string][]chan int),
 	}
+}
+
+type mockNotificationStream struct {
+	sendErr  error
+	recvResp *committerpb.NotificationResponse
+	recvErr  error
+}
+
+func (m *mockNotificationStream) Send(req *committerpb.NotificationRequest) error { return m.sendErr }
+func (m *mockNotificationStream) Recv() (*committerpb.NotificationResponse, error) {
+	return m.recvResp, m.recvErr
+}
+func (*mockNotificationStream) Header() (metadata.MD, error) { return nil, nil }
+func (*mockNotificationStream) Trailer() metadata.MD         { return nil }
+func (*mockNotificationStream) CloseSend() error             { return nil }
+func (*mockNotificationStream) Context() context.Context     { return context.Background() }
+func (*mockNotificationStream) SendMsg(_ any) error          { return nil }
+func (*mockNotificationStream) RecvMsg(_ any) error          { return nil }
+
+type mockNotifierClient struct {
+	stream  grpc.BidiStreamingClient[committerpb.NotificationRequest, committerpb.NotificationResponse]
+	openErr error
+}
+
+func (m *mockNotifierClient) OpenNotificationStream(
+	_ context.Context,
+	_ ...grpc.CallOption,
+) (grpc.BidiStreamingClient[committerpb.NotificationRequest, committerpb.NotificationResponse], error) {
+	return m.stream, m.openErr
 }
 
 // parseResponse tests
@@ -192,6 +223,44 @@ func TestNotificationClient_Subscribe_Timeout(t *testing.T) {
 	require.Error(t, err)
 	// Should get DeadlineExceeded since the context timeout is short.
 	require.ErrorContains(t, err, "deadline exceeded")
+}
+
+func TestNewNotificationClient_FailsFastWhenStreamStartupFails(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("stream unavailable")
+	closed := false
+
+	nc, err := newNotificationClient(
+		t.Context(),
+		config.NotificationsConfig{WaitingTimeout: time.Second},
+		&mockNotifierClient{openErr: expectedErr},
+		func() { closed = true },
+	)
+
+	require.Nil(t, nc)
+	require.ErrorIs(t, err, expectedErr)
+	require.True(t, closed)
+}
+
+func TestNotificationClient_Start_StoresStartupError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("stream unavailable")
+	nc := &NotificationClient{
+		cfg:           config.NotificationsConfig{WaitingTimeout: time.Second},
+		notifyClient:  &mockNotifierClient{openErr: expectedErr},
+		requestQueue:  make(chan *committerpb.NotificationRequest),
+		responseQueue: make(chan *committerpb.NotificationResponse),
+		subscribers:   make(map[string][]chan int),
+	}
+
+	err := nc.start(t.Context())
+	require.ErrorIs(t, err, expectedErr)
+
+	stored := nc.streamErr.Load()
+	require.NotNil(t, stored)
+	require.ErrorIs(t, *stored, expectedErr)
 }
 
 // Close tests

--- a/tools/fxconfig/internal/provider/provider.go
+++ b/tools/fxconfig/internal/provider/provider.go
@@ -21,6 +21,7 @@ type Provider[T any, K Validatable] struct {
 	instance          T
 	err               error
 	cfg               K
+	initialized       bool
 	validationContext validation.Context
 }
 
@@ -42,6 +43,7 @@ func New[T any, K Validatable](
 // Subsequent calls return the cached instance. Thread-safe.
 func (p *Provider[T, K]) Get() (T, error) {
 	p.once.Do(func() {
+		p.initialized = true
 		if err := p.cfg.Validate(p.validationContext); err != nil {
 			p.err = err
 			return
@@ -54,6 +56,21 @@ func (p *Provider[T, K]) Get() (T, error) {
 // Validate delegates to the configuration's Validate method.
 func (p *Provider[T, K]) Validate() error {
 	return p.cfg.Validate(p.validationContext)
+}
+
+// Close releases the cached instance if it was initialized successfully and
+// implements a Close() error method. Non-closeable instances are ignored.
+func (p *Provider[T, K]) Close() error {
+	if !p.initialized || p.err != nil {
+		return nil
+	}
+
+	closer, ok := any(p.instance).(interface{ Close() error })
+	if !ok {
+		return nil
+	}
+
+	return closer.Close()
 }
 
 // Validatable defines the interface for configuration types that can be validated.

--- a/tools/fxconfig/internal/provider/provider_test.go
+++ b/tools/fxconfig/internal/provider/provider_test.go
@@ -190,3 +190,52 @@ func TestProvider_Validate_Error(t *testing.T) {
 	err := p.Validate()
 	require.ErrorIs(t, err, expectedErr)
 }
+
+type closeableMockService struct {
+	closeErr   error
+	closeCalls int
+}
+
+func (m *closeableMockService) Close() error {
+	m.closeCalls++
+	return m.closeErr
+}
+
+func TestProvider_Close_NoOpBeforeGet(t *testing.T) {
+	t.Parallel()
+
+	cfg := &mockConfig{}
+	p := provider.New(func(*mockConfig) (*closeableMockService, error) {
+		return &closeableMockService{}, nil
+	}, cfg, validation.Context{})
+
+	require.NoError(t, p.Close())
+}
+
+func TestProvider_Close_ClosesCachedInstance(t *testing.T) {
+	t.Parallel()
+
+	expected := &closeableMockService{}
+	cfg := &mockConfig{}
+	p := provider.New(func(*mockConfig) (*closeableMockService, error) {
+		return expected, nil
+	}, cfg, validation.Context{})
+
+	_, err := p.Get()
+	require.NoError(t, err)
+	require.NoError(t, p.Close())
+	require.Equal(t, 1, expected.closeCalls)
+}
+
+func TestProvider_Close_IgnoresFailedInitialization(t *testing.T) {
+	t.Parallel()
+
+	cfg := &mockConfig{validateErr: errors.New("validation error")}
+	p := provider.New(func(*mockConfig) (*closeableMockService, error) {
+		return &closeableMockService{}, nil
+	}, cfg, validation.Context{})
+
+	_, err := p.Get()
+	require.Error(t, err)
+	require.NoError(t, p.Close())
+}

--- a/tools/fxconfig/main.go
+++ b/tools/fxconfig/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/signal"
 
@@ -74,5 +75,10 @@ func run() error {
 		},
 	)
 
-	return cmd.ExecuteContext(ctx)
+	err := cmd.ExecuteContext(ctx)
+	if cliCtx.App != nil {
+		err = errors.Join(err, cliCtx.App.Close())
+	}
+
+	return err
 }


### PR DESCRIPTION
#### Type of change

- Bug fix
- Improvement (improvement to code, performance, etc)
- Test update

#### Description

This PR fixes notification client initialization in `fxconfig` so that notification stream startup failures are surfaced immediately.

Currently, `NewNotificationClient()` starts the listener in a background goroutine and returns success before the underlying notification stream is confirmed to be usable. If the stream fails to open, the caller can still receive a client object even though the stream is already broken.

This change makes notification client creation fail fast instead.

The main changes are:

- update `NewNotificationClient()` to wait for initial stream establishment before returning success
- add an internal startup handshake so stream initialization errors are returned directly to the caller
- preserve `streamErr` handling so later stream failures still cause `Subscribe()` to fail fast
- add regression tests for failed notification stream startup and startup error propagation

This improves reliability for notification-dependent flows such as `SubmitTransactionWithWait()` by ensuring callers do not proceed with a client whose stream was never established.

#### Additional details (Optional)

Regression coverage was added for:

- notification client creation failing fast when stream startup fails
- startup errors being stored and observable on the client
- existing subscribe / wait behavior remaining intact

Validation performed:

```bash
go test -v ./tools/fxconfig/internal/client
go test -v ./tools/fxconfig/internal/app
```

Also checked:
```bash
git diff --check
```

Closes #154 