### PR TITLE
Add context support to Close methods in adaptor interferaces

### DIFF
--- a/tools/fxconfig/internal/adapters/api.go
+++ b/tools/fxconfig/internal/adapters/api.go
@@ -25,7 +25,7 @@ type OrdererClient interface {
 	// Broadcast sends a signed transaction to the ordering service.
 	Broadcast(ctx context.Context, signer msp.SigningIdentity, txID string, tx *applicationpb.Tx) error
 	// Close releases resources held by the client.
-	Close() error
+	Close(ctx context.Context) error
 }
 
 // OrdererProvider creates and validates OrdererClient instances.
@@ -41,7 +41,7 @@ type QueryClient interface {
 	// GetNamespacePolicies fetches current namespace policy configurations.
 	GetNamespacePolicies(ctx context.Context) (*applicationpb.NamespacePolicies, error)
 	// Close releases resources held by the client.
-	Close() error
+	Close(ctx context.Context) error
 }
 
 // QueryProvider creates and validates QueryClient instances.
@@ -59,7 +59,7 @@ type NotificationClient interface {
 	// WaitForEvent blocks until a transaction event is received on the subscription.
 	WaitForEvent(ctx context.Context, subscription chan int) (int, error)
 	// Close releases resources held by the client.
-	Close() error
+	Close(ctx context.Context) error
 }
 
 // NotificationProvider creates and validates NotificationClient instances.


### PR DESCRIPTION
Closes #174
 **Type of change**

* Improvement (API consistency)

 **Description**

This PR updates adapter interfaces to include `context.Context` in `Close` methods.
This aligns `Close` with other methods that already accept context, enabling better control over cancellation, timeouts, and resource handling.

**Additional details**

* Updated method signatures from `Close()` to `Close(ctx context.Context)`
* No runtime logic changes; interface-level update only

 **Testing**

* Verified successful build with `go build ./...`

**Related issues**

N/A
