### PR TITLE
Fixes #172: improve CLI error handling and formatting consistency

### DIFF
--- a/tools/configtxgen/main.go
+++ b/tools/configtxgen/main.go
@@ -72,14 +72,15 @@ func main() {
 					"which contains configtx.yaml with the specified profile")
 				os.Exit(1)
 			}
-			logger.Panic(err)
+			logger.Errorf("Unexpected error during config generation: %v", err)
+os.Exit(1)
 		}
 	}()
 
 	logger.Info("Loading configuration")
 	err := factory.InitFactories(nil)
 	if err != nil {
-		logger.Fatalf("Error on initFactories: %s", err)
+		logger.Fatalf("Failed to initialize crypto factories: %v", err)
 	}
 	var profileConfig *configtxgen.Profile
 	if outputBlock != "" || outputChannelCreateTx != "" {
@@ -108,25 +109,25 @@ func main() {
 
 	if outputBlock != "" {
 		if err := configtxgen.DoOutputBlock(profileConfig, channelID, outputBlock); err != nil {
-			logger.Fatalf("Error on outputBlock: %s", err)
+			logger.Fatalf("Error on outputBlock: %v", err)
 		}
 	}
 
 	if outputChannelCreateTx != "" {
 		if err := configtxgen.DoOutputChannelCreateTx(profileConfig, baseProfile, channelID, outputChannelCreateTx); err != nil {
-			logger.Fatalf("Error on outputChannelCreateTx: %s", err)
+			logger.Fatalf("Error on outputChannelCreateTx: %v", err)
 		}
 	}
 
 	if inspectBlock != "" {
 		if err := configtxgen.DoInspectBlock(inspectBlock); err != nil {
-			logger.Fatalf("Error on inspectBlock: %s", err)
+			logger.Fatalf("Error on inspectBlock: %v", err)
 		}
 	}
 
 	if inspectChannelCreateTx != "" {
 		if err := configtxgen.DoInspectChannelCreateTx(inspectChannelCreateTx); err != nil {
-			logger.Fatalf("Error on inspectChannelCreateTx: %s", err)
+			logger.Fatalf("Error on inspectChannelCreateTx: %v", err)
 		}
 	}
 
@@ -139,7 +140,7 @@ func main() {
 		}
 
 		if err := configtxgen.DoPrintOrg(topLevelConfig, printOrg); err != nil {
-			logger.Fatalf("Error on printOrg: %s", err)
+			logger.Fatalf("Error on printOrg: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
#### Type of change
- Bug fix
- Improvement (code quality and error handling)

#### Description
This PR improves error handling and formatting consistency in the `configtxgen` CLI tool.

#### Changes
- Replaced incorrect `%s` with `%v` for proper Go error formatting
- Removed panic usage in the recover block and replaced it with graceful error handling using `logger.Errorf` and `os.Exit(1)`
- Improved clarity and consistency of CLI error messages

#### Why
Using `%v` is the idiomatic way to format errors in Go. Avoiding panic improves CLI usability by preventing stack traces and providing cleaner, more user-friendly error output.

#### Testing
- Ran `configtxgen` manually with various flag combinations
- Verified improved error messages
- Confirmed no regressions in behavior
- All existing tests pass

#### Related issues
#172 