### PR TITLE
feat(fxconfig): add PKCS#11 / HSM BCCSP support

### DIFF
--- a/tools/fxconfig/internal/config/config.go
+++ b/tools/fxconfig/internal/config/config.go
@@ -51,8 +51,29 @@ type LoggingConfig struct {
 // MSPConfig contains MSP (Membership Service Provider) identity configuration.
 // It specifies which organization identity to use for signing transactions.
 type MSPConfig struct {
-	LocalMspID string `mapstructure:"localMspID" yaml:"localMspID,omitempty" desc:"MSP ID of the organization"`
-	ConfigPath string `mapstructure:"configPath" yaml:"configPath,omitempty" desc:"Path to MSP configuration directory"`
+	LocalMspID string      `mapstructure:"localMspID" yaml:"localMspID,omitempty" desc:"MSP ID of the organization"`
+	ConfigPath string      `mapstructure:"configPath" yaml:"configPath,omitempty" desc:"Path to MSP configuration directory"`
+	BCCSP      BCCSPConfig `mapstructure:"bccsp" yaml:"bccsp,omitempty" desc:"BCCSP (crypto provider) configuration; leave empty for default file-based keystore"`
+}
+
+// BCCSPConfig configures the BCCSP (Blockchain Crypto Service Provider).
+// Leaving PKCS11.Library empty falls back to the default file-based software BCCSP,
+// which reads keys from <ConfigPath>/keystore.
+type BCCSPConfig struct {
+	PKCS11 PKCS11Config `mapstructure:"pkcs11" yaml:"pkcs11,omitempty" desc:"PKCS#11 HSM/KMS provider configuration; enables PKCS11 mode when Library is set"`
+}
+
+// PKCS11Config configures a PKCS#11 HSM/KMS crypto provider.
+// When Library is non-empty, PKCS11 mode is activated and keys are loaded from the HSM
+// rather than from a file-based keystore.
+type PKCS11Config struct {
+	Library        string `mapstructure:"library" yaml:"library,omitempty" desc:"Path to the PKCS#11 shared library (.so)"`
+	Label          string `mapstructure:"label" yaml:"label,omitempty" desc:"PKCS#11 token label"`
+	Pin            string `mapstructure:"pin" yaml:"pin,omitempty" desc:"PKCS#11 user PIN"`
+	Hash           string `mapstructure:"hash" yaml:"hash,omitempty" desc:"Hash family (SHA2 or SHA3)" default:"SHA2"`
+	Security       int    `mapstructure:"security" yaml:"security,omitempty" desc:"Security level in bits (256 or 384)" default:"256"`
+	SoftwareVerify bool   `mapstructure:"softwareVerify" yaml:"softwareVerify,omitempty" desc:"Perform signature verification in software"`
+	Immutable      bool   `mapstructure:"immutable" yaml:"immutable,omitempty" desc:"Treat keys as immutable"`
 }
 
 // TLSConfig specifies TLS settings for secure communication.

--- a/tools/fxconfig/internal/config/config.go
+++ b/tools/fxconfig/internal/config/config.go
@@ -52,27 +52,27 @@ type LoggingConfig struct {
 // It specifies which organization identity to use for signing transactions.
 type MSPConfig struct {
 	LocalMspID string      `mapstructure:"localMspID" yaml:"localMspID,omitempty" desc:"MSP ID of the organization"`
-	ConfigPath string      `mapstructure:"configPath" yaml:"configPath,omitempty" desc:"Path to MSP configuration directory"`
-	BCCSP      BCCSPConfig `mapstructure:"bccsp" yaml:"bccsp,omitempty" desc:"BCCSP (crypto provider) configuration; leave empty for default file-based keystore"`
+	ConfigPath string      `mapstructure:"configPath" yaml:"configPath,omitempty" desc:"MSP config directory"`
+	BCCSP      BCCSPConfig `mapstructure:"bccsp" yaml:"bccsp,omitempty" desc:"BCCSP config; empty uses file keystore"`
 }
 
 // BCCSPConfig configures the BCCSP (Blockchain Crypto Service Provider).
 // Leaving PKCS11.Library empty falls back to the default file-based software BCCSP,
 // which reads keys from <ConfigPath>/keystore.
 type BCCSPConfig struct {
-	PKCS11 PKCS11Config `mapstructure:"pkcs11" yaml:"pkcs11,omitempty" desc:"PKCS#11 HSM/KMS provider configuration; enables PKCS11 mode when Library is set"`
+	PKCS11 PKCS11Config `mapstructure:"pkcs11" yaml:"pkcs11,omitempty" desc:"PKCS#11 config; enabled by Library"`
 }
 
 // PKCS11Config configures a PKCS#11 HSM/KMS crypto provider.
 // When Library is non-empty, PKCS11 mode is activated and keys are loaded from the HSM
 // rather than from a file-based keystore.
 type PKCS11Config struct {
-	Library        string `mapstructure:"library" yaml:"library,omitempty" desc:"Path to the PKCS#11 shared library (.so)"`
+	Library        string `mapstructure:"library" yaml:"library,omitempty" desc:"Path to the PKCS#11 shared library"`
 	Label          string `mapstructure:"label" yaml:"label,omitempty" desc:"PKCS#11 token label"`
 	Pin            string `mapstructure:"pin" yaml:"pin,omitempty" desc:"PKCS#11 user PIN"`
 	Hash           string `mapstructure:"hash" yaml:"hash,omitempty" desc:"Hash family (SHA2 or SHA3)" default:"SHA2"`
-	Security       int    `mapstructure:"security" yaml:"security,omitempty" desc:"Security level in bits (256 or 384)" default:"256"`
-	SoftwareVerify bool   `mapstructure:"softwareVerify" yaml:"softwareVerify,omitempty" desc:"Perform signature verification in software"`
+	Security       int    `mapstructure:"security" yaml:"security,omitempty" desc:"Security bits" default:"256"`
+	SoftwareVerify bool   `mapstructure:"softwareVerify" yaml:"softwareVerify,omitempty" desc:"Software verification"`
 	Immutable      bool   `mapstructure:"immutable" yaml:"immutable,omitempty" desc:"Treat keys as immutable"`
 }
 

--- a/tools/fxconfig/internal/msp/signer.go
+++ b/tools/fxconfig/internal/msp/signer.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/hyperledger/fabric-lib-go/bccsp"
+	"github.com/hyperledger/fabric-lib-go/bccsp/pkcs11"
 	"github.com/hyperledger/fabric-lib-go/bccsp/sw"
 
 	"github.com/hyperledger/fabric-x-common/msp"
@@ -34,7 +36,9 @@ func GetSignerIdentityFromMSP(cfg config.MSPConfig) (msp.SigningIdentity, error)
 	return sid, nil
 }
 
-// setupMSP creates an MSP instance with file-based BCCSP keystore from the given configuration.
+// setupMSP creates an MSP instance.
+// Selects PKCS#11 BCCSP when mspCfg.BCCSP.PKCS11.Library is set; otherwise falls back to
+// the default file-based software BCCSP that reads keys from <ConfigPath>/keystore.
 //
 //nolint:ireturn
 func setupMSP(mspCfg config.MSPConfig) (msp.MSP, error) {
@@ -43,17 +47,9 @@ func setupMSP(mspCfg config.MSPConfig) (msp.MSP, error) {
 		return nil, fmt.Errorf("error getting local msp config from %v: %w", mspCfg.ConfigPath, err)
 	}
 
-	// TODO: get proper BCCSP connfiguration via config
-
-	dir := path.Join(mspCfg.ConfigPath, "keystore")
-	ks, err := sw.NewFileBasedKeyStore(nil, dir, true)
+	cp, err := buildBCCSP(mspCfg)
 	if err != nil {
-		return nil, err
-	}
-
-	cp, err := sw.NewDefaultSecurityLevelWithKeystore(ks)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error building BCCSP: %w", err)
 	}
 
 	mspOpts := &msp.BCCSPNewOpts{
@@ -67,10 +63,68 @@ func setupMSP(mspCfg config.MSPConfig) (msp.MSP, error) {
 		return nil, err
 	}
 
-	err = thisMSP.Setup(conf)
-	if err != nil {
+	if err := thisMSP.Setup(conf); err != nil {
 		return nil, err
 	}
 
 	return thisMSP, nil
+}
+
+// buildBCCSP constructs a BCCSP provider based on the MSP configuration.
+// PKCS11 mode activates when mspCfg.BCCSP.PKCS11.Library is non-empty.
+//
+//nolint:ireturn
+func buildBCCSP(mspCfg config.MSPConfig) (bccsp.BCCSP, error) {
+	p := mspCfg.BCCSP.PKCS11
+	if p.Library != "" {
+		return newPKCS11BCCSP(p)
+	}
+	return newFileBasedBCCSP(mspCfg.ConfigPath)
+}
+
+//nolint:ireturn
+func newFileBasedBCCSP(mspConfigPath string) (bccsp.BCCSP, error) {
+	dir := path.Join(mspConfigPath, "keystore")
+	ks, err := sw.NewFileBasedKeyStore(nil, dir, true)
+	if err != nil {
+		return nil, err
+	}
+	return sw.NewDefaultSecurityLevelWithKeystore(ks)
+}
+
+//nolint:ireturn
+func newPKCS11BCCSP(cfg config.PKCS11Config) (bccsp.BCCSP, error) {
+	hash := cfg.Hash
+	if hash == "" {
+		hash = "SHA2"
+	}
+	security := cfg.Security
+	if security == 0 {
+		security = 256
+	}
+
+	opts := pkcs11.PKCS11Opts{
+		Security:       security,
+		Hash:           hash,
+		Library:        cfg.Library,
+		Label:          cfg.Label,
+		Pin:            cfg.Pin,
+		SoftwareVerify: cfg.SoftwareVerify,
+		Immutable:      cfg.Immutable,
+	}
+	return pkcs11.New(opts, &dummyKeyStore{})
+}
+
+// dummyKeyStore is a no-op keystore used with PKCS11.
+// PKCS11 manages keys inside the HSM/KMS; no file-based storage is needed.
+type dummyKeyStore struct{}
+
+func (ks *dummyKeyStore) ReadOnly() bool { return true }
+
+func (ks *dummyKeyStore) GetKey(ski []byte) (bccsp.Key, error) {
+	return nil, fmt.Errorf("not implemented - keys are managed by PKCS11")
+}
+
+func (ks *dummyKeyStore) StoreKey(k bccsp.Key) error {
+	return fmt.Errorf("not implemented - keys are managed by PKCS11")
 }

--- a/tools/fxconfig/internal/msp/signer.go
+++ b/tools/fxconfig/internal/msp/signer.go
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 package msp
 
 import (
+	"errors"
 	"fmt"
 	"path"
 
@@ -119,12 +120,13 @@ func newPKCS11BCCSP(cfg config.PKCS11Config) (bccsp.BCCSP, error) {
 // PKCS11 manages keys inside the HSM/KMS; no file-based storage is needed.
 type dummyKeyStore struct{}
 
-func (ks *dummyKeyStore) ReadOnly() bool { return true }
+func (*dummyKeyStore) ReadOnly() bool { return true }
 
-func (ks *dummyKeyStore) GetKey(ski []byte) (bccsp.Key, error) {
-	return nil, fmt.Errorf("not implemented - keys are managed by PKCS11")
+//nolint:ireturn // interface return is required by the bccsp.KeyStore contract
+func (*dummyKeyStore) GetKey(_ []byte) (bccsp.Key, error) {
+	return nil, errors.New("not implemented - keys are managed by PKCS11")
 }
 
-func (ks *dummyKeyStore) StoreKey(k bccsp.Key) error {
-	return fmt.Errorf("not implemented - keys are managed by PKCS11")
+func (*dummyKeyStore) StoreKey(_ bccsp.Key) error {
+	return errors.New("not implemented - keys are managed by PKCS11")
 }


### PR DESCRIPTION
#### Type of change

- New feature (non-breaking)

#### Description

fxconfig currently hard-codes a file-based software BCCSP that reads keys from `<ConfigPath>/keystore`. Operators who keep MSP private keys in an HSM or an external KMS have no way to configure fxconfig to sign transactions without first exporting keys to disk, which defeats the purpose of the HSM.

This PR adds optional PKCS#11 support, mirroring the configuration shape already used by Fabric / Fabric-X peers and orderers.

## Changes

- Extend `MSPConfig` with a `BCCSPConfig` section containing a `PKCS11Config` (library path, label, pin, hash family, security level, and the usual `softwareVerify` / `immutable` flags).
- When `MSPConfig.BCCSP.PKCS11.Library` is non-empty, `setupMSP` builds a PKCS#11 BCCSP via `fabric-lib-go/bccsp/pkcs11`, backed by a no-op key store (keys live inside the HSM, so file-based key management is unnecessary).
- Otherwise behaviour is unchanged: fxconfig falls back to the existing file-based software BCCSP.

No existing callers are affected — the new fields are zero-value by default and trigger the original code path. An operator opts in by setting `BCCSP.PKCS11.Library` in their fxconfig config.

## Example config

```yaml
msp:
  localMspID: Org1MSP
  configPath: /msp
  bccsp:
    pkcs11:
      library: /usr/local/lib/libsofthsm2.so
      label: TokenLabel
      pin: ${HSM_PIN}
```

## Files changed

- `tools/fxconfig/internal/config/config.go` — add `BCCSPConfig` / `PKCS11Config` structs.
- `tools/fxconfig/internal/msp/signer.go` — build BCCSP based on config; keep file-based path as default.

## Test plan

- [x] Built fxconfig with and without PKCS#11 config; default path unchanged.
- [x] Verified fxconfig signs namespace transactions against an HSM-backed MSP (SoftHSM2) end-to-end in a downstream integration environment.
- [x] CI.
