### PR TITLE
fix(fxconfig): unblock subscribers and fail fast when notification stream terminates

### DIFF
--- a/tools/fxconfig/internal/client/notifications.go
+++ b/tools/fxconfig/internal/client/notifications.go
@@ -19,6 +19,12 @@ import (
 	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/config"
 )
 
+// ErrNotificationStreamClosed is returned when the notification stream has
+// terminated, either because the gRPC stream failed or the client was closed.
+// Callers receive this from Subscribe or WaitForEvent instead of blocking until
+// their own context deadline expires.
+var ErrNotificationStreamClosed = errors.New("notification stream closed")
+
 // NotificationClient provides a gRPC client for receiving transaction status notifications.
 // It manages bidirectional streaming with the committer notification service and multiplexes
 // notifications to multiple subscribers per transaction ID.
@@ -32,6 +38,10 @@ type NotificationClient struct {
 
 	subscribers   map[string][]chan int
 	subscribersMu sync.RWMutex
+
+	// done is closed when listen() returns. Subscribers use it to fail fast
+	// instead of blocking on requestQueue or their own context deadline.
+	done chan struct{}
 }
 
 // NewNotificationClient creates a notification client with the provided configuration.
@@ -54,12 +64,12 @@ func NewNotificationClient(cfg config.NotificationsConfig) (*NotificationClient,
 		requestQueue:  make(chan *committerpb.NotificationRequest),
 		responseQueue: make(chan *committerpb.NotificationResponse),
 		subscribers:   make(map[string][]chan int),
+		done:          make(chan struct{}),
 	}
 
 	go func() {
 		if err := nc.listen(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			fmt.Printf("error: Notification listener stream terminated unexpectedly: %s\n", err)
-			// logger.Errorf("Notification listener stream terminated unexpectedly for %s: %s", key, err)
+			logger.Errorf("Notification listener stream terminated unexpectedly: %s", err)
 		}
 	}()
 
@@ -76,14 +86,32 @@ func (n *NotificationClient) Close() error {
 
 // Subscribe registers interest in a transaction's status and returns a channel for notifications.
 // Multiple subscribers to the same txID share a single upstream subscription.
+// If the listener has terminated, Subscribe fails fast with ErrNotificationStreamClosed
+// instead of blocking on requestQueue.
 func (n *NotificationClient) Subscribe(ctx context.Context, txID string) (chan int, error) {
+	// fast-path checks before mutating state
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	receiverCh := make(chan int, 1)
 
 	n.subscribersMu.Lock()
-	defer n.subscribersMu.Unlock()
+	// Recheck done under the lock so we serialize with listen()'s cleanup: if
+	// cleanup has already closed subscriber channels and cleared the map, we
+	// must not append a stale entry that will never be delivered or closed.
+	select {
+	case <-n.done:
+		n.subscribersMu.Unlock()
+		return nil, ErrNotificationStreamClosed
+	default:
+	}
 
 	subscribers := n.subscribers[txID]
 	n.subscribers[txID] = append(subscribers, receiverCh)
+	n.subscribersMu.Unlock()
 
 	if len(subscribers) > 0 {
 		// we already have an active subscription for this txID
@@ -98,17 +126,12 @@ func (n *NotificationClient) Subscribe(ctx context.Context, txID string) (chan i
 		Timeout: durationpb.New(n.cfg.WaitingTimeout),
 	}
 
-	// check if our ctx is still open
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
-	}
-
 	// try to push to request queue
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
+	case <-n.done:
+		return nil, ErrNotificationStreamClosed
 	case n.requestQueue <- req:
 	}
 
@@ -130,11 +153,13 @@ func wait(ctx context.Context, subscription chan int) (int, error) {
 	default:
 	}
 
-	// try to push to request queue
 	select {
 	case <-ctx.Done():
 		return 0, ctx.Err()
-	case status := <-subscription:
+	case status, ok := <-subscription:
+		if !ok {
+			return 0, ErrNotificationStreamClosed
+		}
 		return status, nil
 	}
 }
@@ -232,8 +257,19 @@ func (n *NotificationClient) listen(ctx context.Context) error {
 
 	err = g.Wait()
 
-	// Cleanup subscribers map when listen() exits
+	// Signal termination first so Subscribe() can detect stream death under
+	// the lock before any new entries are appended to the map.
+	close(n.done)
+
+	// Close every waiting subscriber channel so callers in wait() unblock
+	// with ErrNotificationStreamClosed immediately, without waiting for their
+	// own context deadline to expire.
 	n.subscribersMu.Lock()
+	for _, receivers := range n.subscribers {
+		for _, ch := range receivers {
+			close(ch)
+		}
+	}
 	clear(n.subscribers)
 	n.subscribersMu.Unlock()
 

--- a/tools/fxconfig/internal/client/notifications_test.go
+++ b/tools/fxconfig/internal/client/notifications_test.go
@@ -25,6 +25,7 @@ func newTestNotificationClient(waitingTimeout time.Duration) *NotificationClient
 		requestQueue:  make(chan *committerpb.NotificationRequest),
 		responseQueue: make(chan *committerpb.NotificationResponse),
 		subscribers:   make(map[string][]chan int),
+		done:          make(chan struct{}),
 	}
 }
 
@@ -183,4 +184,51 @@ func TestNotificationClient_Close_NilFunc(t *testing.T) {
 
 	nc := &NotificationClient{}
 	require.NoError(t, nc.Close())
+}
+
+// Stream termination tests
+
+// TestNotificationClient_ListenExit_UnblocksWaitForEvent verifies that when the
+// listener goroutine terminates (simulated by closing subscriber channels and done),
+// WaitForEvent returns ErrNotificationStreamClosed instead of hanging until the
+// caller's context deadline.
+func TestNotificationClient_ListenExit_UnblocksWaitForEvent(t *testing.T) {
+	t.Parallel()
+
+	nc := newTestNotificationClient(10 * time.Second)
+
+	// Register a subscriber as if Subscribe() had been called.
+	ch := make(chan int, 1)
+	nc.subscribersMu.Lock()
+	nc.subscribers["tx-orphan"] = []chan int{ch}
+	nc.subscribersMu.Unlock()
+
+	// Simulate listen() exiting: close subscriber channels, clear map, close done.
+	nc.subscribersMu.Lock()
+	for _, receivers := range nc.subscribers {
+		for _, c := range receivers {
+			close(c)
+		}
+	}
+	clear(nc.subscribers)
+	nc.subscribersMu.Unlock()
+	close(nc.done)
+
+	// WaitForEvent must return ErrNotificationStreamClosed immediately, not block
+	// for the 10-second WaitingTimeout.
+	_, err := nc.WaitForEvent(t.Context(), ch)
+	require.ErrorIs(t, err, ErrNotificationStreamClosed)
+}
+
+// TestNotificationClient_SubscribeAfterListenExit_ReturnsSentinel verifies that
+// Subscribe fails fast with ErrNotificationStreamClosed after the listener has
+// exited, rather than blocking forever on the unbuffered requestQueue.
+func TestNotificationClient_SubscribeAfterListenExit_ReturnsSentinel(t *testing.T) {
+	t.Parallel()
+
+	nc := newTestNotificationClient(10 * time.Second)
+	close(nc.done)
+
+	_, err := nc.Subscribe(t.Context(), "tx-dead")
+	require.ErrorIs(t, err, ErrNotificationStreamClosed)
 }

--- a/tools/fxconfig/internal/client/orderer.go
+++ b/tools/fxconfig/internal/client/orderer.go
@@ -95,7 +95,7 @@ func (oc *OrdererClient) send(ctx context.Context, env *cb.Envelope) error {
 	}
 
 	if status.GetStatus() != cb.Status_SUCCESS {
-		return fmt.Errorf("got error %#v", status.GetStatus())
+		return fmt.Errorf("orderer rejected transaction with status %s", status.GetStatus())
 	}
 
 	return nil


### PR DESCRIPTION
I was reading through the notification client code and noticed that when the listener goroutine exits — say the committer restarts or the gRPC stream drops — callers end up in a pretty bad state.

**What's broken today:**

The cleanup in `listen()` calls `clear(n.subscribers)` but never closes the subscriber channels. So if you're in the middle of a `WaitForEvent` call when the stream dies, you just sit there until your own `WaitingTimeout` expires — which can be a long time. Meanwhile, any new `Subscribe` call after the listener exits blocks forever on the unbuffered `requestQueue` because nobody's reading from it anymore. The client becomes a zombie that silently hangs everything.

There's also a leftover `fmt.Printf` on the error path even though the package already has a `flogging` logger declared in `client.go`.

**What this PR does:**

- Adds a `done chan struct{}` to `NotificationClient`, closed by `listen()` before it clears the map.
- During cleanup, closes every subscriber channel so callers in `wait()` get `ErrNotificationStreamClosed` immediately instead of hanging.
- `Subscribe()` checks `done` under the map lock (to serialize with cleanup) and also on the `requestQueue` select, returning the same sentinel error. Holding the lock for the `done` check is important — it prevents a race where a new subscriber appends to the map after cleanup already ran.
- `wait()` uses a two-value channel receive to distinguish a closed channel from an actual status delivery.
- Replaces `fmt.Printf` with `logger.Errorf` using the existing package logger.
- Fixes `orderer.go` to use `%s` when formatting the rejection status so you get `FORBIDDEN` instead of `0xb`.

**Tests:**

Two new tests alongside the existing ones:
- `TestNotificationClient_ListenExit_UnblocksWaitForEvent` — simulates listener exit and verifies `WaitForEvent` returns `ErrNotificationStreamClosed` right away, not after the 10-second timeout.
- `TestNotificationClient_SubscribeAfterListenExit_ReturnsSentinel` — verifies `Subscribe` returns the sentinel immediately after listener death rather than blocking.

All existing unit tests pass. Integration tests require Docker so they weren't run locally.

Fixes #109
Fixes #164
Partial progress on #154

Signed-off-by: Shridhar Panigrahi <sridharpanigrahi2006@gmail.com>