### PR TITLE
feat(fxmigrate): implement verify command and genesis file reader

### DIFF
--- a/tools/fxconfig/internal/client/notifications_test.go
+++ b/tools/fxconfig/internal/client/notifications_test.go
@@ -184,3 +184,193 @@ func TestNotificationClient_Close_NilFunc(t *testing.T) {
 	nc := &NotificationClient{}
 	require.NoError(t, nc.Close())
 }
+
+// Concurrent subscriber tests
+
+func TestNotificationClient_ConcurrentSubscribers_SameTxID_BothReceive(t *testing.T) {
+	t.Parallel()
+
+	nc := newTestNotificationClient(2 * time.Second)
+
+	// First subscriber — drains the request queue so Subscribe doesn't block
+	go func() { <-nc.requestQueue }()
+	ch1, err := nc.Subscribe(t.Context(), "tx-concurrent")
+	require.NoError(t, err)
+
+	// Second subscriber on the same txID — takes the duplicate path (no requestQueue send)
+	ch2, err := nc.Subscribe(t.Context(), "tx-concurrent")
+	require.NoError(t, err)
+
+	// Simulate the dispatcher: lock, collect receivers, delete entry, unlock, deliver
+	resp := parseResponse(&committerpb.NotificationResponse{
+		TxStatusEvents: []*committerpb.TxStatus{
+			{
+				Ref:    &committerpb.TxRef{TxId: "tx-concurrent"},
+				Status: committerpb.Status_COMMITTED,
+			},
+		},
+	})
+
+	nc.subscribersMu.Lock()
+	type call struct {
+		ch     chan int
+		status int
+	}
+	var calls []call
+	for txID, v := range resp {
+		receivers, ok := nc.subscribers[txID]
+		if !ok {
+			continue
+		}
+		delete(nc.subscribers, txID)
+		for _, q := range receivers {
+			calls = append(calls, call{ch: q, status: v})
+		}
+	}
+	nc.subscribersMu.Unlock()
+
+	// Deliver using the same non-blocking send the real dispatcher uses
+	for _, c := range calls {
+		select {
+		case c.ch <- c.status:
+		default:
+			// dropped — this is what we're testing against
+		}
+	}
+
+	// Both subscribers must receive the status
+	select {
+	case s := <-ch1:
+		require.Equal(t, int(committerpb.Status_COMMITTED), s)
+	case <-time.After(time.Second):
+		t.Fatal("ch1: timed out — first subscriber was starved")
+	}
+
+	select {
+	case s := <-ch2:
+		require.Equal(t, int(committerpb.Status_COMMITTED), s)
+	case <-time.After(time.Second):
+		t.Fatal("ch2: timed out — notification silently dropped for duplicate subscriber")
+	}
+}
+
+func TestNotificationClient_SubscribeAfterDispatch_DoesNotHang(t *testing.T) {
+	t.Parallel()
+
+	nc := newTestNotificationClient(500 * time.Millisecond)
+
+	// First subscriber
+	go func() { <-nc.requestQueue }()
+	ch1, err := nc.Subscribe(t.Context(), "tx-resubscribe")
+	require.NoError(t, err)
+
+	// Simulate the dispatcher deleting the txID entry after delivering
+	nc.subscribersMu.Lock()
+	receivers := nc.subscribers["tx-resubscribe"]
+	delete(nc.subscribers, "tx-resubscribe")
+	nc.subscribersMu.Unlock()
+
+	// Deliver to the first subscriber
+	for _, r := range receivers {
+		r <- int(committerpb.Status_COMMITTED)
+	}
+	s := <-ch1
+	require.Equal(t, int(committerpb.Status_COMMITTED), s)
+
+	// A new subscriber arrives for the same txID after dispatch.
+	// This takes the fresh-subscription path and pushes to requestQueue.
+	// With no listener draining the queue, it must respect context cancellation
+	// and NOT hang indefinitely.
+	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+
+	_, err = nc.Subscribe(ctx, "tx-resubscribe")
+	// Must fail with deadline exceeded — not hang forever
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestNotificationClient_ListenExit_ClearsSubscribers(t *testing.T) {
+	t.Parallel()
+
+	nc := newTestNotificationClient(2 * time.Second)
+
+	// Pre-populate subscribers as if Subscribe() was called
+	ch := make(chan int, 1)
+	nc.subscribersMu.Lock()
+	nc.subscribers["tx-orphan"] = []chan int{ch}
+	nc.subscribersMu.Unlock()
+
+	// Simulate listen() exiting — it calls clear(n.subscribers)
+	nc.subscribersMu.Lock()
+	clear(nc.subscribers)
+	nc.subscribersMu.Unlock()
+
+	// Verify subscriber map is empty
+	nc.subscribersMu.RLock()
+	require.Empty(t, nc.subscribers)
+	nc.subscribersMu.RUnlock()
+
+	// WaitForEvent must timeout — the channel will never receive because
+	// no dispatcher is running and listen() has cleaned up
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+	_, err := nc.WaitForEvent(ctx, ch)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestNotificationClient_ConcurrentSubscribeAndDispatch(t *testing.T) {
+	t.Parallel()
+
+	nc := newTestNotificationClient(2 * time.Second)
+
+	const subscriberCount = 10
+	channels := make([]chan int, subscriberCount)
+
+	// First subscriber triggers the upstream request
+	go func() { <-nc.requestQueue }()
+	ch, err := nc.Subscribe(t.Context(), "tx-race")
+	require.NoError(t, err)
+	channels[0] = ch
+
+	// Remaining subscribers take the duplicate path (no requestQueue send)
+	for i := 1; i < subscriberCount; i++ {
+		ch, err := nc.Subscribe(t.Context(), "tx-race")
+		require.NoError(t, err)
+		channels[i] = ch
+	}
+
+	// Verify all subscribers are registered
+	nc.subscribersMu.RLock()
+	require.Len(t, nc.subscribers["tx-race"], subscriberCount)
+	nc.subscribersMu.RUnlock()
+
+	// Simulate dispatcher delivery
+	status := int(committerpb.Status_COMMITTED)
+	nc.subscribersMu.Lock()
+	receivers := nc.subscribers["tx-race"]
+	delete(nc.subscribers, "tx-race")
+	nc.subscribersMu.Unlock()
+
+	for _, r := range receivers {
+		select {
+		case r <- status:
+		default:
+		}
+	}
+
+	// ALL subscribers must receive the notification
+	for i, ch := range channels {
+		select {
+		case s := <-ch:
+			require.Equal(t, status, s, "subscriber %d got wrong status", i)
+		case <-time.After(time.Second):
+			t.Fatalf("subscriber %d: timed out — notification dropped", i)
+		}
+	}
+
+	// Map entry must be gone after dispatch
+	nc.subscribersMu.RLock()
+	_, exists := nc.subscribers["tx-race"]
+	nc.subscribersMu.RUnlock()
+	require.False(t, exists, "subscriber entry should be deleted after dispatch")
+}

--- a/tools/fxmigrate/internal/cli/v1/export.go
+++ b/tools/fxmigrate/internal/cli/v1/export.go
@@ -1,0 +1,117 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package v1
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/hyperledger/fabric-x/tools/fxmigrate/internal/genesis"
+	"github.com/hyperledger/fabric-x/tools/fxmigrate/internal/snapshot"
+)
+
+// NewExportCommand returns the export subcommand.
+// It reads a Fabric peer snapshot directory and writes a Fabric-X genesis-data file.
+func NewExportCommand() *cobra.Command {
+	var (
+		snapshotDir string
+		outputFile  string
+		channel     string
+		namespace   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export a Fabric peer snapshot into a Fabric-X genesis-data file",
+		Long: `export reads a Hyperledger Fabric peer snapshot directory and produces
+a verifiable genesis-data file compatible with the Fabric-X committer's
+--init-from-snapshot bootstrap mode.
+
+The tool applies the following transformations:
+  - Strips all private-data-collection (PDC) hash keys ($$h$$ pattern)
+  - Strips PDC private state keys ($$p$$ pattern)
+  - Strips implicit org collection keys
+  - Strips system chaincode namespaces (lscc, _lifecycle, etc.)
+  - Converts Fabric block-version pairs to Fabric-X scalar BIGINT versions
+  - Maps the source channel to the specified Fabric-X namespace
+
+Example:
+  fxmigrate export \
+    --snapshot ./peer/snapshots/completed/mychannel/100 \
+    --channel  mychannel \
+    --namespace token \
+    --output   genesis.bin`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runExport(cmd, snapshotDir, channel, namespace, outputFile)
+		},
+	}
+
+	cmd.Flags().StringVar(&snapshotDir, "snapshot", "", "Path to the Fabric peer snapshot directory (required)")
+	cmd.Flags().StringVar(&channel, "channel", "", "Source Fabric channel name (required)")
+	cmd.Flags().StringVar(&namespace, "namespace", "", "Target Fabric-X namespace name (required)")
+	cmd.Flags().StringVar(&outputFile, "output", "genesis.bin", "Output genesis-data file path")
+
+	_ = cmd.MarkFlagRequired("snapshot")
+	_ = cmd.MarkFlagRequired("channel")
+	_ = cmd.MarkFlagRequired("namespace")
+
+	return cmd
+}
+
+func runExport(cmd *cobra.Command, snapshotDir, channel, namespace, outputFile string) error {
+	// Phase 1: Verify snapshot integrity
+	fmt.Fprintf(cmd.OutOrStdout(), "Phase 1/5: Verifying snapshot integrity...\n")
+	meta, err := snapshot.ReadManifest(snapshotDir)
+	if err != nil {
+		return fmt.Errorf("snapshot integrity check failed: %w", err)
+	}
+	if meta.ChannelName != channel {
+		return fmt.Errorf("snapshot channel %q does not match --channel %q", meta.ChannelName, channel)
+	}
+	if err := snapshot.VerifyChecksums(snapshotDir, meta); err != nil {
+		return fmt.Errorf("snapshot checksum mismatch: %w", err)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "  channel=%s block_height=%d db_type=%s\n",
+		meta.ChannelName, meta.LastBlockNumber, meta.StateDBType)
+
+	// Phase 2: Discover namespaces in public state
+	fmt.Fprintf(cmd.OutOrStdout(), "Phase 2/5: Discovering namespaces...\n")
+	namespaces, err := snapshot.DiscoverNamespaces(snapshotDir)
+	if err != nil {
+		return fmt.Errorf("namespace discovery failed: %w", err)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "  found %d namespace(s): %v\n", len(namespaces), namespaces)
+
+	// Phase 3: Export state
+	fmt.Fprintf(cmd.OutOrStdout(), "Phase 3/5: Exporting state (channel=%s → namespace=%s)...\n", channel, namespace)
+	entries, err := snapshot.ExportState(snapshotDir)
+	if err != nil {
+		return fmt.Errorf("state export failed: %w", err)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "  exported %d key-value pairs\n", len(entries))
+
+	// Phase 4: Write genesis-data file
+	fmt.Fprintf(cmd.OutOrStdout(), "Phase 4/5: Writing genesis-data file → %s...\n", outputFile)
+	if err := genesis.Write(outputFile, namespace, meta, entries); err != nil {
+		return fmt.Errorf("failed to write genesis-data file: %w", err)
+	}
+
+	// Phase 5: Generate and print manifest
+	fmt.Fprintf(cmd.OutOrStdout(), "Phase 5/5: Computing output checksum...\n")
+	checksum, err := genesis.Checksum(outputFile)
+	if err != nil {
+		return fmt.Errorf("failed to compute checksum: %w", err)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "\nDone.\n")
+	fmt.Fprintf(cmd.OutOrStdout(), "  output:   %s\n", outputFile)
+	fmt.Fprintf(cmd.OutOrStdout(), "  sha256:   %s\n", checksum)
+	fmt.Fprintf(cmd.OutOrStdout(), "  entries:  %d\n", len(entries))
+	fmt.Fprintf(cmd.OutOrStdout(), "  channel:  %s → namespace: %s\n", channel, namespace)
+
+	return nil
+}

--- a/tools/fxmigrate/internal/cli/v1/export.go
+++ b/tools/fxmigrate/internal/cli/v1/export.go
@@ -15,15 +15,19 @@ import (
 	"github.com/hyperledger/fabric-x/tools/fxmigrate/internal/snapshot"
 )
 
+// exportOptions groups the CLI flags consumed by runExport so the function
+// signature stays under the revive argument-limit.
+type exportOptions struct {
+	snapshotDir string
+	channel     string
+	namespace   string
+	outputFile  string
+}
+
 // NewExportCommand returns the export subcommand.
 // It reads a Fabric peer snapshot directory and writes a Fabric-X genesis-data file.
 func NewExportCommand() *cobra.Command {
-	var (
-		snapshotDir string
-		outputFile  string
-		channel     string
-		namespace   string
-	)
+	var opts exportOptions
 
 	cmd := &cobra.Command{
 		Use:   "export",
@@ -47,14 +51,14 @@ Example:
     --namespace token \
     --output   genesis.bin`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runExport(cmd, snapshotDir, channel, namespace, outputFile)
+			return runExport(cmd, opts)
 		},
 	}
 
-	cmd.Flags().StringVar(&snapshotDir, "snapshot", "", "Path to the Fabric peer snapshot directory (required)")
-	cmd.Flags().StringVar(&channel, "channel", "", "Source Fabric channel name (required)")
-	cmd.Flags().StringVar(&namespace, "namespace", "", "Target Fabric-X namespace name (required)")
-	cmd.Flags().StringVar(&outputFile, "output", "genesis.bin", "Output genesis-data file path")
+	cmd.Flags().StringVar(&opts.snapshotDir, "snapshot", "", "Path to the Fabric peer snapshot directory (required)")
+	cmd.Flags().StringVar(&opts.channel, "channel", "", "Source Fabric channel name (required)")
+	cmd.Flags().StringVar(&opts.namespace, "namespace", "", "Target Fabric-X namespace name (required)")
+	cmd.Flags().StringVar(&opts.outputFile, "output", "genesis.bin", "Output genesis-data file path")
 
 	_ = cmd.MarkFlagRequired("snapshot")
 	_ = cmd.MarkFlagRequired("channel")
@@ -63,55 +67,57 @@ Example:
 	return cmd
 }
 
-func runExport(cmd *cobra.Command, snapshotDir, channel, namespace, outputFile string) error {
+func runExport(cmd *cobra.Command, opts exportOptions) error {
+	out := cmd.OutOrStdout()
+
 	// Phase 1: Verify snapshot integrity
-	fmt.Fprintf(cmd.OutOrStdout(), "Phase 1/5: Verifying snapshot integrity...\n")
-	meta, err := snapshot.ReadManifest(snapshotDir)
+	_, _ = fmt.Fprintln(out, "Phase 1/5: Verifying snapshot integrity...")
+	meta, err := snapshot.ReadManifest(opts.snapshotDir)
 	if err != nil {
 		return fmt.Errorf("snapshot integrity check failed: %w", err)
 	}
-	if meta.ChannelName != channel {
-		return fmt.Errorf("snapshot channel %q does not match --channel %q", meta.ChannelName, channel)
+	if meta.ChannelName != opts.channel {
+		return fmt.Errorf("snapshot channel %q does not match --channel %q", meta.ChannelName, opts.channel)
 	}
-	if err := snapshot.VerifyChecksums(snapshotDir, meta); err != nil {
-		return fmt.Errorf("snapshot checksum mismatch: %w", err)
+	if cerr := snapshot.VerifyChecksums(opts.snapshotDir, meta); cerr != nil {
+		return fmt.Errorf("snapshot checksum mismatch: %w", cerr)
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "  channel=%s block_height=%d db_type=%s\n",
+	_, _ = fmt.Fprintf(out, "  channel=%s block_height=%d db_type=%s\n",
 		meta.ChannelName, meta.LastBlockNumber, meta.StateDBType)
 
 	// Phase 2: Discover namespaces in public state
-	fmt.Fprintf(cmd.OutOrStdout(), "Phase 2/5: Discovering namespaces...\n")
-	namespaces, err := snapshot.DiscoverNamespaces(snapshotDir)
+	_, _ = fmt.Fprintln(out, "Phase 2/5: Discovering namespaces...")
+	namespaces, err := snapshot.DiscoverNamespaces(opts.snapshotDir)
 	if err != nil {
 		return fmt.Errorf("namespace discovery failed: %w", err)
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "  found %d namespace(s): %v\n", len(namespaces), namespaces)
+	_, _ = fmt.Fprintf(out, "  found %d namespace(s): %v\n", len(namespaces), namespaces)
 
 	// Phase 3: Export state
-	fmt.Fprintf(cmd.OutOrStdout(), "Phase 3/5: Exporting state (channel=%s → namespace=%s)...\n", channel, namespace)
-	entries, err := snapshot.ExportState(snapshotDir)
+	_, _ = fmt.Fprintf(out, "Phase 3/5: Exporting state (channel=%s → namespace=%s)...\n", opts.channel, opts.namespace)
+	entries, err := snapshot.ExportState(opts.snapshotDir)
 	if err != nil {
 		return fmt.Errorf("state export failed: %w", err)
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "  exported %d key-value pairs\n", len(entries))
+	_, _ = fmt.Fprintf(out, "  exported %d key-value pairs\n", len(entries))
 
 	// Phase 4: Write genesis-data file
-	fmt.Fprintf(cmd.OutOrStdout(), "Phase 4/5: Writing genesis-data file → %s...\n", outputFile)
-	if err := genesis.Write(outputFile, namespace, meta, entries); err != nil {
-		return fmt.Errorf("failed to write genesis-data file: %w", err)
+	_, _ = fmt.Fprintf(out, "Phase 4/5: Writing genesis-data file → %s...\n", opts.outputFile)
+	if werr := genesis.Write(opts.outputFile, opts.namespace, meta, entries); werr != nil {
+		return fmt.Errorf("failed to write genesis-data file: %w", werr)
 	}
 
 	// Phase 5: Generate and print manifest
-	fmt.Fprintf(cmd.OutOrStdout(), "Phase 5/5: Computing output checksum...\n")
-	checksum, err := genesis.Checksum(outputFile)
+	_, _ = fmt.Fprintln(out, "Phase 5/5: Computing output checksum...")
+	checksum, err := genesis.Checksum(opts.outputFile)
 	if err != nil {
 		return fmt.Errorf("failed to compute checksum: %w", err)
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "\nDone.\n")
-	fmt.Fprintf(cmd.OutOrStdout(), "  output:   %s\n", outputFile)
-	fmt.Fprintf(cmd.OutOrStdout(), "  sha256:   %s\n", checksum)
-	fmt.Fprintf(cmd.OutOrStdout(), "  entries:  %d\n", len(entries))
-	fmt.Fprintf(cmd.OutOrStdout(), "  channel:  %s → namespace: %s\n", channel, namespace)
+	_, _ = fmt.Fprintln(out, "\nDone.")
+	_, _ = fmt.Fprintf(out, "  output:   %s\n", opts.outputFile)
+	_, _ = fmt.Fprintf(out, "  sha256:   %s\n", checksum)
+	_, _ = fmt.Fprintf(out, "  entries:  %d\n", len(entries))
+	_, _ = fmt.Fprintf(out, "  channel:  %s → namespace: %s\n", opts.channel, opts.namespace)
 
 	return nil
 }

--- a/tools/fxmigrate/internal/cli/v1/root.go
+++ b/tools/fxmigrate/internal/cli/v1/root.go
@@ -1,0 +1,40 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package v1 implements the command-line interface for fxmigrate.
+package v1
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewRootCommand constructs and returns the root cobra command for fxmigrate.
+func NewRootCommand() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:   "fxmigrate",
+		Short: "CLI tool for migrating Hyperledger Fabric ledger state to Fabric-X",
+		Long: `fxmigrate is a command-line tool for migrating world state from a
+Hyperledger Fabric network to Fabric-X.
+
+It reads a standard Fabric peer snapshot directory, applies namespace
+mapping, strips private-data-collection artefacts, and produces a
+verifiable genesis-data file that the Fabric-X committer can ingest
+via its --init-from-snapshot bootstrap mode.
+
+Commands:
+  export   Export a Fabric peer snapshot into a Fabric-X genesis-data file
+  verify   Verify integrity between a Fabric snapshot and a live Fabric-X state DB
+  version  Print the fxmigrate version`,
+	}
+
+	rootCmd.SilenceUsage = true
+
+	rootCmd.AddCommand(NewVersionCommand())
+	rootCmd.AddCommand(NewExportCommand())
+	rootCmd.AddCommand(NewVerifyCommand())
+
+	return rootCmd
+}

--- a/tools/fxmigrate/internal/cli/v1/verify.go
+++ b/tools/fxmigrate/internal/cli/v1/verify.go
@@ -1,0 +1,38 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package v1
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// NewVerifyCommand returns the verify subcommand.
+// Post-migration integrity verification is tracked in a follow-up PR once
+// the committer bootstrap feature lands.
+func NewVerifyCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "verify",
+		Short: "Verify integrity between a Fabric snapshot and a Fabric-X state DB (coming soon)",
+		Long: `verify compares key-value counts and cryptographic hashes between
+a source Fabric peer snapshot and a live Fabric-X state database.
+
+It produces a human-readable integrity report with:
+  - Row count comparison per namespace
+  - Block height match
+  - Sampled key-value deep comparison
+  - Policy registration check
+
+Note: this command is a placeholder — full implementation follows once the
+committer --init-from-snapshot bootstrap feature is merged.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			fmt.Fprintln(cmd.OutOrStdout(), "verify: not yet implemented — tracked in follow-up PR")
+			return nil
+		},
+	}
+}

--- a/tools/fxmigrate/internal/cli/v1/verify.go
+++ b/tools/fxmigrate/internal/cli/v1/verify.go
@@ -10,29 +10,107 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/hyperledger/fabric-x/tools/fxmigrate/internal/genesis"
+	"github.com/hyperledger/fabric-x/tools/fxmigrate/internal/snapshot"
 )
 
 // NewVerifyCommand returns the verify subcommand.
-// Post-migration integrity verification is tracked in a follow-up PR once
-// the committer bootstrap feature lands.
+// It reads a genesis-data file produced by "export" and cross-checks it against
+// the source Fabric snapshot to confirm no entries were lost or corrupted.
 func NewVerifyCommand() *cobra.Command {
-	return &cobra.Command{
+	var (
+		genesisFile string
+		snapshotDir string
+	)
+
+	cmd := &cobra.Command{
 		Use:   "verify",
-		Short: "Verify integrity between a Fabric snapshot and a Fabric-X state DB (coming soon)",
-		Long: `verify compares key-value counts and cryptographic hashes between
-a source Fabric peer snapshot and a live Fabric-X state database.
+		Short: "Verify integrity between a genesis-data file and the source Fabric snapshot",
+		Long: `verify reads a genesis-data file produced by "fxmigrate export" and
+cross-checks it against the original Fabric peer snapshot directory.
 
-It produces a human-readable integrity report with:
-  - Row count comparison per namespace
-  - Block height match
-  - Sampled key-value deep comparison
-  - Policy registration check
+Checks performed:
+  1. Genesis file header is well-formed and readable.
+  2. Actual entry count in the file matches the count in the header.
+  3. Source snapshot entry count (after the same PDC/system-cc filtering)
+     matches the genesis entry count.
+  4. Block height in the header matches the snapshot block height.
 
-Note: this command is a placeholder — full implementation follows once the
-committer --init-from-snapshot bootstrap feature is merged.`,
+Example:
+  fxmigrate verify \
+    --genesis  genesis.bin \
+    --snapshot ./peer/snapshots/completed/mychannel/100`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			fmt.Fprintln(cmd.OutOrStdout(), "verify: not yet implemented — tracked in follow-up PR")
-			return nil
+			return runVerify(cmd, genesisFile, snapshotDir)
 		},
 	}
+
+	cmd.Flags().StringVar(&genesisFile, "genesis", "", "Path to the genesis-data file produced by export (required)")
+	cmd.Flags().StringVar(&snapshotDir, "snapshot", "", "Path to the source Fabric peer snapshot directory (required)")
+
+	_ = cmd.MarkFlagRequired("genesis")
+	_ = cmd.MarkFlagRequired("snapshot")
+
+	return cmd
+}
+
+func runVerify(cmd *cobra.Command, genesisFile, snapshotDir string) error {
+	out := cmd.OutOrStdout()
+
+	// Step 1: read genesis file header and all entries.
+	fmt.Fprintf(out, "Step 1/4: Reading genesis-data file: %s\n", genesisFile)
+	hdr, entries, err := genesis.ReadAll(genesisFile)
+	if err != nil {
+		return fmt.Errorf("cannot read genesis file: %w", err)
+	}
+	fmt.Fprintf(out, "  namespace:       %s\n", hdr.Namespace)
+	fmt.Fprintf(out, "  source_channel:  %s\n", hdr.SourceChannel)
+	fmt.Fprintf(out, "  block_height:    %d\n", hdr.BlockHeight)
+	fmt.Fprintf(out, "  exported_at:     %s\n", hdr.ExportedAt)
+	fmt.Fprintf(out, "  header says:     %d entries\n", hdr.EntryCount)
+
+	genesisChecksum, err := genesis.Checksum(genesisFile)
+	if err != nil {
+		return fmt.Errorf("cannot checksum genesis file: %w", err)
+	}
+	fmt.Fprintf(out, "  sha256:          %s\n", genesisChecksum)
+
+	// Step 2: verify actual entry count matches the header.
+	fmt.Fprintf(out, "\nStep 2/4: Verifying entry count matches header...\n")
+	actualCount := len(entries)
+	if actualCount != hdr.EntryCount {
+		return fmt.Errorf("genesis file is corrupt: header declares %d entries but file contains %d",
+			hdr.EntryCount, actualCount)
+	}
+	fmt.Fprintf(out, "  entries in file: %d  OK\n", actualCount)
+
+	// Step 3: verify the snapshot block height.
+	fmt.Fprintf(out, "\nStep 3/4: Verifying snapshot block height...\n")
+	meta, err := snapshot.ReadManifest(snapshotDir)
+	if err != nil {
+		return fmt.Errorf("cannot read snapshot manifest: %w", err)
+	}
+	if meta.LastBlockNumber != hdr.BlockHeight {
+		return fmt.Errorf("block height mismatch: genesis says %d, snapshot says %d",
+			hdr.BlockHeight, meta.LastBlockNumber)
+	}
+	fmt.Fprintf(out, "  block_height: %d  OK\n", meta.LastBlockNumber)
+
+	// Step 4: compare filtered entry count from the snapshot.
+	fmt.Fprintf(out, "\nStep 4/4: Counting filtered entries in source snapshot...\n")
+	snapshotEntries, err := snapshot.ExportState(snapshotDir)
+	if err != nil {
+		return fmt.Errorf("cannot read snapshot state: %w", err)
+	}
+	snapshotCount := len(snapshotEntries)
+	fmt.Fprintf(out, "  snapshot entries (filtered): %d\n", snapshotCount)
+	if snapshotCount != actualCount {
+		return fmt.Errorf("entry count mismatch: genesis has %d entries, snapshot has %d after filtering",
+			actualCount, snapshotCount)
+	}
+	fmt.Fprintf(out, "  entry counts match  OK\n")
+
+	fmt.Fprintf(out, "\nResult: OK — genesis-data file integrity verified.\n")
+	return nil
 }

--- a/tools/fxmigrate/internal/cli/v1/verify.go
+++ b/tools/fxmigrate/internal/cli/v1/verify.go
@@ -59,34 +59,34 @@ func runVerify(cmd *cobra.Command, genesisFile, snapshotDir string) error {
 	out := cmd.OutOrStdout()
 
 	// Step 1: read genesis file header and all entries.
-	fmt.Fprintf(out, "Step 1/4: Reading genesis-data file: %s\n", genesisFile)
+	_, _ = fmt.Fprintf(out, "Step 1/4: Reading genesis-data file: %s\n", genesisFile)
 	hdr, entries, err := genesis.ReadAll(genesisFile)
 	if err != nil {
 		return fmt.Errorf("cannot read genesis file: %w", err)
 	}
-	fmt.Fprintf(out, "  namespace:       %s\n", hdr.Namespace)
-	fmt.Fprintf(out, "  source_channel:  %s\n", hdr.SourceChannel)
-	fmt.Fprintf(out, "  block_height:    %d\n", hdr.BlockHeight)
-	fmt.Fprintf(out, "  exported_at:     %s\n", hdr.ExportedAt)
-	fmt.Fprintf(out, "  header says:     %d entries\n", hdr.EntryCount)
+	_, _ = fmt.Fprintf(out, "  namespace:       %s\n", hdr.Namespace)
+	_, _ = fmt.Fprintf(out, "  source_channel:  %s\n", hdr.SourceChannel)
+	_, _ = fmt.Fprintf(out, "  block_height:    %d\n", hdr.BlockHeight)
+	_, _ = fmt.Fprintf(out, "  exported_at:     %s\n", hdr.ExportedAt)
+	_, _ = fmt.Fprintf(out, "  header says:     %d entries\n", hdr.EntryCount)
 
 	genesisChecksum, err := genesis.Checksum(genesisFile)
 	if err != nil {
 		return fmt.Errorf("cannot checksum genesis file: %w", err)
 	}
-	fmt.Fprintf(out, "  sha256:          %s\n", genesisChecksum)
+	_, _ = fmt.Fprintf(out, "  sha256:          %s\n", genesisChecksum)
 
 	// Step 2: verify actual entry count matches the header.
-	fmt.Fprintf(out, "\nStep 2/4: Verifying entry count matches header...\n")
+	_, _ = fmt.Fprintln(out, "\nStep 2/4: Verifying entry count matches header...")
 	actualCount := len(entries)
 	if actualCount != hdr.EntryCount {
 		return fmt.Errorf("genesis file is corrupt: header declares %d entries but file contains %d",
 			hdr.EntryCount, actualCount)
 	}
-	fmt.Fprintf(out, "  entries in file: %d  OK\n", actualCount)
+	_, _ = fmt.Fprintf(out, "  entries in file: %d  OK\n", actualCount)
 
 	// Step 3: verify the snapshot block height.
-	fmt.Fprintf(out, "\nStep 3/4: Verifying snapshot block height...\n")
+	_, _ = fmt.Fprintln(out, "\nStep 3/4: Verifying snapshot block height...")
 	meta, err := snapshot.ReadManifest(snapshotDir)
 	if err != nil {
 		return fmt.Errorf("cannot read snapshot manifest: %w", err)
@@ -95,22 +95,22 @@ func runVerify(cmd *cobra.Command, genesisFile, snapshotDir string) error {
 		return fmt.Errorf("block height mismatch: genesis says %d, snapshot says %d",
 			hdr.BlockHeight, meta.LastBlockNumber)
 	}
-	fmt.Fprintf(out, "  block_height: %d  OK\n", meta.LastBlockNumber)
+	_, _ = fmt.Fprintf(out, "  block_height: %d  OK\n", meta.LastBlockNumber)
 
 	// Step 4: compare filtered entry count from the snapshot.
-	fmt.Fprintf(out, "\nStep 4/4: Counting filtered entries in source snapshot...\n")
+	_, _ = fmt.Fprintln(out, "\nStep 4/4: Counting filtered entries in source snapshot...")
 	snapshotEntries, err := snapshot.ExportState(snapshotDir)
 	if err != nil {
 		return fmt.Errorf("cannot read snapshot state: %w", err)
 	}
 	snapshotCount := len(snapshotEntries)
-	fmt.Fprintf(out, "  snapshot entries (filtered): %d\n", snapshotCount)
+	_, _ = fmt.Fprintf(out, "  snapshot entries (filtered): %d\n", snapshotCount)
 	if snapshotCount != actualCount {
 		return fmt.Errorf("entry count mismatch: genesis has %d entries, snapshot has %d after filtering",
 			actualCount, snapshotCount)
 	}
-	fmt.Fprintf(out, "  entry counts match  OK\n")
+	_, _ = fmt.Fprintln(out, "  entry counts match  OK")
 
-	fmt.Fprintf(out, "\nResult: OK — genesis-data file integrity verified.\n")
+	_, _ = fmt.Fprintln(out, "\nResult: OK — genesis-data file integrity verified.")
 	return nil
 }

--- a/tools/fxmigrate/internal/cli/v1/version.go
+++ b/tools/fxmigrate/internal/cli/v1/version.go
@@ -1,0 +1,26 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package v1
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const version = "0.1.0"
+
+// NewVersionCommand returns the version subcommand.
+func NewVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the fxmigrate version",
+		Run: func(cmd *cobra.Command, _ []string) {
+			fmt.Fprintf(cmd.OutOrStdout(), "fxmigrate v%s\n", version)
+		},
+	}
+}

--- a/tools/fxmigrate/internal/cli/v1/version.go
+++ b/tools/fxmigrate/internal/cli/v1/version.go
@@ -20,7 +20,7 @@ func NewVersionCommand() *cobra.Command {
 		Use:   "version",
 		Short: "Print the fxmigrate version",
 		Run: func(cmd *cobra.Command, _ []string) {
-			fmt.Fprintf(cmd.OutOrStdout(), "fxmigrate v%s\n", version)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "fxmigrate v%s\n", version)
 		},
 	}
 }

--- a/tools/fxmigrate/internal/genesis/reader.go
+++ b/tools/fxmigrate/internal/genesis/reader.go
@@ -10,6 +10,7 @@ import (
 	"bufio"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -24,7 +25,7 @@ func ReadHeader(path string) (*FileHeader, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot open genesis file: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	r := bufio.NewReader(f)
 	return readHeader(r)
@@ -37,7 +38,7 @@ func ReadAll(path string) (*FileHeader, []snapshot.StateEntry, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot open genesis file: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	r := bufio.NewReaderSize(f, 1<<20)
 
@@ -48,22 +49,22 @@ func ReadAll(path string) (*FileHeader, []snapshot.StateEntry, error) {
 
 	entries := make([]snapshot.StateEntry, 0, hdr.EntryCount)
 	for {
-		key, err := readBytes(r)
-		if err == io.EOF {
+		key, kerr := readBytes(r)
+		if errors.Is(kerr, io.EOF) {
 			break
 		}
-		if err != nil {
-			return nil, nil, fmt.Errorf("reading key: %w", err)
+		if kerr != nil {
+			return nil, nil, fmt.Errorf("reading key: %w", kerr)
 		}
 
-		value, err := readBytes(r)
-		if err != nil {
-			return nil, nil, fmt.Errorf("reading value: %w", err)
+		value, verr := readBytes(r)
+		if verr != nil {
+			return nil, nil, fmt.Errorf("reading value: %w", verr)
 		}
 
-		version, err := readUint64(r)
-		if err != nil {
-			return nil, nil, fmt.Errorf("reading version: %w", err)
+		version, xerr := readUint64(r)
+		if xerr != nil {
+			return nil, nil, fmt.Errorf("reading version: %w", xerr)
 		}
 
 		entries = append(entries, snapshot.StateEntry{

--- a/tools/fxmigrate/internal/genesis/reader.go
+++ b/tools/fxmigrate/internal/genesis/reader.go
@@ -1,0 +1,124 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package genesis
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/hyperledger/fabric-x/tools/fxmigrate/internal/snapshot"
+)
+
+// ReadHeader opens the genesis-data file at path and returns its header.
+// The file is closed after reading the header.
+func ReadHeader(path string) (*FileHeader, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open genesis file: %w", err)
+	}
+	defer f.Close()
+
+	r := bufio.NewReader(f)
+	return readHeader(r)
+}
+
+// ReadAll opens the genesis-data file at path, parses the header and all
+// entries, and returns them. For large files use a streaming approach instead.
+func ReadAll(path string) (*FileHeader, []snapshot.StateEntry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot open genesis file: %w", err)
+	}
+	defer f.Close()
+
+	r := bufio.NewReaderSize(f, 1<<20)
+
+	hdr, err := readHeader(r)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	entries := make([]snapshot.StateEntry, 0, hdr.EntryCount)
+	for {
+		key, err := readBytes(r)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, nil, fmt.Errorf("reading key: %w", err)
+		}
+
+		value, err := readBytes(r)
+		if err != nil {
+			return nil, nil, fmt.Errorf("reading value: %w", err)
+		}
+
+		version, err := readUint64(r)
+		if err != nil {
+			return nil, nil, fmt.Errorf("reading version: %w", err)
+		}
+
+		entries = append(entries, snapshot.StateEntry{
+			Key:     string(key),
+			Value:   value,
+			Version: version,
+		})
+	}
+
+	return hdr, entries, nil
+}
+
+func readHeader(r *bufio.Reader) (*FileHeader, error) {
+	hdrLen, err := readUint32(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading header length: %w", err)
+	}
+
+	hdrBytes := make([]byte, hdrLen)
+	if _, err := io.ReadFull(r, hdrBytes); err != nil {
+		return nil, fmt.Errorf("reading header bytes: %w", err)
+	}
+
+	var hdr FileHeader
+	if err := json.Unmarshal(hdrBytes, &hdr); err != nil {
+		return nil, fmt.Errorf("parsing header: %w", err)
+	}
+
+	return &hdr, nil
+}
+
+func readUint32(r io.Reader) (uint32, error) {
+	var buf [4]byte
+	if _, err := io.ReadFull(r, buf[:]); err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint32(buf[:]), nil
+}
+
+func readUint64(r io.Reader) (uint64, error) {
+	var buf [8]byte
+	if _, err := io.ReadFull(r, buf[:]); err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint64(buf[:]), nil
+}
+
+func readBytes(r io.Reader) ([]byte, error) {
+	length, err := readUint32(r)
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, length)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}

--- a/tools/fxmigrate/internal/genesis/reader_test.go
+++ b/tools/fxmigrate/internal/genesis/reader_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package genesis
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/fabric-x/tools/fxmigrate/internal/snapshot"
+)
+
+func makeManifest(channel string, blockHeight uint64) *snapshot.Manifest {
+	return &snapshot.Manifest{
+		ChannelName:     channel,
+		LastBlockNumber: blockHeight,
+		StateDBType:     "goleveldb",
+	}
+}
+
+func TestReadHeader_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "genesis.bin")
+	meta := makeManifest("mychannel", 42)
+	entries := []snapshot.StateEntry{
+		{Key: "k1", Value: []byte("v1"), Version: 1},
+		{Key: "k2", Value: []byte("v2"), Version: 2},
+	}
+
+	require.NoError(t, Write(path, "token", meta, entries))
+
+	hdr, err := ReadHeader(path)
+	require.NoError(t, err)
+	require.Equal(t, "1", hdr.Version)
+	require.Equal(t, "token", hdr.Namespace)
+	require.Equal(t, "mychannel", hdr.SourceChannel)
+	require.Equal(t, uint64(42), hdr.BlockHeight)
+	require.Equal(t, 2, hdr.EntryCount)
+}
+
+func TestReadAll_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "genesis.bin")
+	meta := makeManifest("ch1", 100)
+	want := []snapshot.StateEntry{
+		{Key: "alpha", Value: []byte("aaa"), Version: 10},
+		{Key: "beta", Value: []byte("bbb"), Version: 20},
+		{Key: "gamma", Value: []byte("ccc"), Version: 30},
+	}
+
+	require.NoError(t, Write(path, "ns1", meta, want))
+
+	hdr, got, err := ReadAll(path)
+	require.NoError(t, err)
+	require.Equal(t, 3, hdr.EntryCount)
+	require.Len(t, got, 3)
+
+	for i, e := range got {
+		require.Equal(t, want[i].Key, e.Key)
+		require.Equal(t, want[i].Value, e.Value)
+		require.Equal(t, want[i].Version, e.Version)
+	}
+}
+
+func TestReadAll_Empty(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "empty.bin")
+	meta := makeManifest("ch", 0)
+
+	require.NoError(t, Write(path, "ns", meta, nil))
+
+	hdr, entries, err := ReadAll(path)
+	require.NoError(t, err)
+	require.Equal(t, 0, hdr.EntryCount)
+	require.Empty(t, entries)
+}
+
+func TestReadHeader_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := ReadHeader(filepath.Join(t.TempDir(), "nonexistent.bin"))
+	require.Error(t, err)
+}
+
+func TestReadAll_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := ReadAll(filepath.Join(t.TempDir(), "nonexistent.bin"))
+	require.Error(t, err)
+}
+
+func TestReadAll_BinaryValues(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "binary.bin")
+	meta := makeManifest("ch", 5)
+	want := []snapshot.StateEntry{
+		{Key: "bin", Value: []byte{0x00, 0x01, 0xFF, 0xFE}, Version: 99},
+	}
+
+	require.NoError(t, Write(path, "ns", meta, want))
+
+	_, got, err := ReadAll(path)
+	require.NoError(t, err)
+	require.Equal(t, want[0].Value, got[0].Value)
+}

--- a/tools/fxmigrate/internal/genesis/writer.go
+++ b/tools/fxmigrate/internal/genesis/writer.go
@@ -1,0 +1,126 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package genesis handles writing the Fabric-X genesis-data file that the
+// committer's --init-from-snapshot bootstrap mode ingests.
+package genesis
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/hyperledger/fabric-x/tools/fxmigrate/internal/snapshot"
+)
+
+// FileHeader is written at the start of every genesis-data file so the
+// committer can reject files intended for a different namespace or produced
+// by a different tool version.
+type FileHeader struct {
+	Version       string `json:"version"`
+	Namespace     string `json:"namespace"`
+	SourceChannel string `json:"source_channel"`
+	BlockHeight   uint64 `json:"block_height"`
+	ExportedAt    string `json:"exported_at"`
+	EntryCount    int    `json:"entry_count"`
+}
+
+// Write creates the genesis-data file at path.
+//
+// File format (sequential, no framing overhead):
+//
+//	[header_len uint32][header JSON bytes]
+//	for each entry:
+//	  [key_len uint32][key bytes]
+//	  [value_len uint32][value bytes]
+//	  [version uint64]
+func Write(path, namespace string, meta *snapshot.Manifest, entries []snapshot.StateEntry) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("cannot create output file: %w", err)
+	}
+	defer f.Close()
+
+	w := bufio.NewWriterSize(f, 1<<20)
+
+	// Write header
+	hdr := FileHeader{
+		Version:       "1",
+		Namespace:     namespace,
+		SourceChannel: meta.ChannelName,
+		BlockHeight:   meta.LastBlockNumber,
+		ExportedAt:    time.Now().UTC().Format(time.RFC3339),
+		EntryCount:    len(entries),
+	}
+	hdrBytes, err := json.Marshal(hdr)
+	if err != nil {
+		return fmt.Errorf("cannot marshal header: %w", err)
+	}
+	if err := writeUint32(w, uint32(len(hdrBytes))); err != nil {
+		return err
+	}
+	if _, err := w.Write(hdrBytes); err != nil {
+		return err
+	}
+
+	// Write entries
+	for _, e := range entries {
+		if err := writeBytes(w, []byte(e.Key)); err != nil {
+			return fmt.Errorf("writing key: %w", err)
+		}
+		if err := writeBytes(w, e.Value); err != nil {
+			return fmt.Errorf("writing value: %w", err)
+		}
+		if err := writeUint64(w, e.Version); err != nil {
+			return fmt.Errorf("writing version: %w", err)
+		}
+	}
+
+	return w.Flush()
+}
+
+// Checksum returns the hex-encoded SHA-256 hash of the file at path.
+func Checksum(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func writeUint32(w io.Writer, v uint32) error {
+	var buf [4]byte
+	binary.BigEndian.PutUint32(buf[:], v)
+	_, err := w.Write(buf[:])
+	return err
+}
+
+func writeUint64(w io.Writer, v uint64) error {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], v)
+	_, err := w.Write(buf[:])
+	return err
+}
+
+func writeBytes(w io.Writer, b []byte) error {
+	if err := writeUint32(w, uint32(len(b))); err != nil {
+		return err
+	}
+	_, err := w.Write(b)
+	return err
+}

--- a/tools/fxmigrate/internal/genesis/writer.go
+++ b/tools/fxmigrate/internal/genesis/writer.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"time"
 
@@ -43,12 +44,16 @@ type FileHeader struct {
 //	  [key_len uint32][key bytes]
 //	  [value_len uint32][value bytes]
 //	  [version uint64]
-func Write(path, namespace string, meta *snapshot.Manifest, entries []snapshot.StateEntry) error {
+func Write(path, namespace string, meta *snapshot.Manifest, entries []snapshot.StateEntry) (err error) {
 	f, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("cannot create output file: %w", err)
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("closing output file: %w", cerr)
+		}
+	}()
 
 	w := bufio.NewWriterSize(f, 1<<20)
 
@@ -65,23 +70,27 @@ func Write(path, namespace string, meta *snapshot.Manifest, entries []snapshot.S
 	if err != nil {
 		return fmt.Errorf("cannot marshal header: %w", err)
 	}
-	if err := writeUint32(w, uint32(len(hdrBytes))); err != nil {
-		return err
+	if len(hdrBytes) > math.MaxUint32 {
+		return fmt.Errorf("header too large: %d bytes", len(hdrBytes))
 	}
-	if _, err := w.Write(hdrBytes); err != nil {
-		return err
+	//nolint:gosec // G115: length is bounds-checked above against math.MaxUint32.
+	if werr := writeUint32(w, uint32(len(hdrBytes))); werr != nil {
+		return werr
+	}
+	if _, werr := w.Write(hdrBytes); werr != nil {
+		return werr
 	}
 
 	// Write entries
 	for _, e := range entries {
-		if err := writeBytes(w, []byte(e.Key)); err != nil {
-			return fmt.Errorf("writing key: %w", err)
+		if werr := writeBytes(w, []byte(e.Key)); werr != nil {
+			return fmt.Errorf("writing key: %w", werr)
 		}
-		if err := writeBytes(w, e.Value); err != nil {
-			return fmt.Errorf("writing value: %w", err)
+		if werr := writeBytes(w, e.Value); werr != nil {
+			return fmt.Errorf("writing value: %w", werr)
 		}
-		if err := writeUint64(w, e.Version); err != nil {
-			return fmt.Errorf("writing version: %w", err)
+		if werr := writeUint64(w, e.Version); werr != nil {
+			return fmt.Errorf("writing version: %w", werr)
 		}
 	}
 
@@ -94,7 +103,7 @@ func Checksum(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
@@ -118,6 +127,10 @@ func writeUint64(w io.Writer, v uint64) error {
 }
 
 func writeBytes(w io.Writer, b []byte) error {
+	if len(b) > math.MaxUint32 {
+		return fmt.Errorf("byte slice too large: %d bytes", len(b))
+	}
+	//nolint:gosec // G115: length is bounds-checked above against math.MaxUint32.
 	if err := writeUint32(w, uint32(len(b))); err != nil {
 		return err
 	}

--- a/tools/fxmigrate/internal/genesis/writer_test.go
+++ b/tools/fxmigrate/internal/genesis/writer_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package genesis
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/fabric-x/tools/fxmigrate/internal/snapshot"
+)
+
+func testMeta(channel string, height uint64) *snapshot.Manifest {
+	return &snapshot.Manifest{
+		ChannelName:     channel,
+		LastBlockNumber: height,
+		StateDBType:     "goleveldb",
+		FileHashes:      map[string]string{},
+	}
+}
+
+func testEntries() []snapshot.StateEntry {
+	return []snapshot.StateEntry{
+		{Namespace: "mycc", Key: "asset1", Value: []byte("val1"), Version: (5 << 32) | 2},
+		{Namespace: "mycc", Key: "asset2", Value: []byte("val2"), Version: (10 << 32) | 0},
+	}
+}
+
+// readFile parses the genesis-data file and returns the header and raw entries.
+func readFile(t *testing.T, path string) (FileHeader, []snapshot.StateEntry) {
+	t.Helper()
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	r := bufio.NewReader(f)
+
+	read32 := func() uint32 {
+		var buf [4]byte
+		_, err := io.ReadFull(r, buf[:])
+		require.NoError(t, err)
+		return binary.BigEndian.Uint32(buf[:])
+	}
+	read64 := func() uint64 {
+		var buf [8]byte
+		_, err := io.ReadFull(r, buf[:])
+		require.NoError(t, err)
+		return binary.BigEndian.Uint64(buf[:])
+	}
+	readBytes := func() []byte {
+		n := read32()
+		if n == 0 {
+			return nil
+		}
+		buf := make([]byte, n)
+		_, err := io.ReadFull(r, buf)
+		require.NoError(t, err)
+		return buf
+	}
+
+	hdrBytes := readBytes()
+	var hdr FileHeader
+	require.NoError(t, json.Unmarshal(hdrBytes, &hdr))
+
+	var entries []snapshot.StateEntry
+	for {
+		keyBytes := make([]byte, 0)
+		var keyLen uint32
+		if err := binary.Read(r, binary.BigEndian, &keyLen); err == io.EOF {
+			break
+		} else {
+			require.NoError(t, err)
+		}
+		if keyLen > 0 {
+			keyBytes = make([]byte, keyLen)
+			_, err := io.ReadFull(r, keyBytes)
+			require.NoError(t, err)
+		}
+
+		valBytes := readBytes()
+		ver := read64()
+
+		entries = append(entries, snapshot.StateEntry{
+			Key:     string(keyBytes),
+			Value:   valBytes,
+			Version: ver,
+		})
+	}
+
+	return hdr, entries
+}
+
+func TestWrite_Header(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "genesis.bin")
+	meta := testMeta("mychannel", 100)
+	entries := testEntries()
+
+	require.NoError(t, Write(path, "token", meta, entries))
+
+	hdr, _ := readFile(t, path)
+	require.Equal(t, "1", hdr.Version)
+	require.Equal(t, "token", hdr.Namespace)
+	require.Equal(t, "mychannel", hdr.SourceChannel)
+	require.Equal(t, uint64(100), hdr.BlockHeight)
+	require.Equal(t, len(entries), hdr.EntryCount)
+}
+
+func TestWrite_Entries(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "genesis.bin")
+	entries := testEntries()
+
+	require.NoError(t, Write(path, "token", testMeta("mychannel", 1), entries))
+
+	_, got := readFile(t, path)
+	require.Len(t, got, len(entries))
+	require.Equal(t, "asset1", got[0].Key)
+	require.Equal(t, []byte("val1"), got[0].Value)
+	require.Equal(t, uint64((5<<32)|2), got[0].Version)
+	require.Equal(t, "asset2", got[1].Key)
+	require.Equal(t, uint64(10<<32), got[1].Version)
+}
+
+func TestWrite_EmptyEntries(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "genesis.bin")
+	require.NoError(t, Write(path, "token", testMeta("mychannel", 0), nil))
+
+	hdr, entries := readFile(t, path)
+	require.Equal(t, 0, hdr.EntryCount)
+	require.Empty(t, entries)
+}
+
+func TestChecksum_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	p1 := filepath.Join(dir, "a.bin")
+	p2 := filepath.Join(dir, "b.bin")
+
+	meta := testMeta("mychannel", 5)
+	entries := testEntries()
+
+	require.NoError(t, Write(p1, "token", meta, entries))
+	require.NoError(t, Write(p2, "token", meta, entries))
+
+	// ExportedAt timestamps may differ — just verify checksum is non-empty and consistent per file
+	c1, err := Checksum(p1)
+	require.NoError(t, err)
+	require.Len(t, c1, 64) // hex SHA-256
+
+	c2, err := Checksum(p2)
+	require.NoError(t, err)
+	require.Len(t, c2, 64)
+}
+
+func TestChecksum_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := Checksum(filepath.Join(t.TempDir(), "missing.bin"))
+	require.Error(t, err)
+}

--- a/tools/fxmigrate/internal/genesis/writer_test.go
+++ b/tools/fxmigrate/internal/genesis/writer_test.go
@@ -10,6 +10,7 @@ import (
 	"bufio"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -20,9 +21,9 @@ import (
 	"github.com/hyperledger/fabric-x/tools/fxmigrate/internal/snapshot"
 )
 
-func testMeta(channel string, height uint64) *snapshot.Manifest {
+func testMeta(height uint64) *snapshot.Manifest {
 	return &snapshot.Manifest{
-		ChannelName:     channel,
+		ChannelName:     "mychannel",
 		LastBlockNumber: height,
 		StateDBType:     "goleveldb",
 		FileHashes:      map[string]string{},
@@ -32,7 +33,7 @@ func testMeta(channel string, height uint64) *snapshot.Manifest {
 func testEntries() []snapshot.StateEntry {
 	return []snapshot.StateEntry{
 		{Namespace: "mycc", Key: "asset1", Value: []byte("val1"), Version: (5 << 32) | 2},
-		{Namespace: "mycc", Key: "asset2", Value: []byte("val2"), Version: (10 << 32) | 0},
+		{Namespace: "mycc", Key: "asset2", Value: []byte("val2"), Version: 10 << 32},
 	}
 }
 
@@ -41,7 +42,7 @@ func readFile(t *testing.T, path string) (FileHeader, []snapshot.StateEntry) {
 	t.Helper()
 	f, err := os.Open(path)
 	require.NoError(t, err)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	r := bufio.NewReader(f)
 
@@ -76,11 +77,11 @@ func readFile(t *testing.T, path string) (FileHeader, []snapshot.StateEntry) {
 	for {
 		keyBytes := make([]byte, 0)
 		var keyLen uint32
-		if err := binary.Read(r, binary.BigEndian, &keyLen); err == io.EOF {
+		err := binary.Read(r, binary.BigEndian, &keyLen)
+		if errors.Is(err, io.EOF) {
 			break
-		} else {
-			require.NoError(t, err)
 		}
+		require.NoError(t, err)
 		if keyLen > 0 {
 			keyBytes = make([]byte, keyLen)
 			_, err := io.ReadFull(r, keyBytes)
@@ -104,7 +105,7 @@ func TestWrite_Header(t *testing.T) {
 	t.Parallel()
 
 	path := filepath.Join(t.TempDir(), "genesis.bin")
-	meta := testMeta("mychannel", 100)
+	meta := testMeta(100)
 	entries := testEntries()
 
 	require.NoError(t, Write(path, "token", meta, entries))
@@ -123,7 +124,7 @@ func TestWrite_Entries(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "genesis.bin")
 	entries := testEntries()
 
-	require.NoError(t, Write(path, "token", testMeta("mychannel", 1), entries))
+	require.NoError(t, Write(path, "token", testMeta(1), entries))
 
 	_, got := readFile(t, path)
 	require.Len(t, got, len(entries))
@@ -138,7 +139,7 @@ func TestWrite_EmptyEntries(t *testing.T) {
 	t.Parallel()
 
 	path := filepath.Join(t.TempDir(), "genesis.bin")
-	require.NoError(t, Write(path, "token", testMeta("mychannel", 0), nil))
+	require.NoError(t, Write(path, "token", testMeta(0), nil))
 
 	hdr, entries := readFile(t, path)
 	require.Equal(t, 0, hdr.EntryCount)
@@ -152,7 +153,7 @@ func TestChecksum_Deterministic(t *testing.T) {
 	p1 := filepath.Join(dir, "a.bin")
 	p2 := filepath.Join(dir, "b.bin")
 
-	meta := testMeta("mychannel", 5)
+	meta := testMeta(5)
 	entries := testEntries()
 
 	require.NoError(t, Write(p1, "token", meta, entries))

--- a/tools/fxmigrate/internal/snapshot/filter.go
+++ b/tools/fxmigrate/internal/snapshot/filter.go
@@ -11,12 +11,12 @@ import "strings"
 // systemChaincodes is the set of Fabric system chaincode namespaces that
 // have no equivalent in Fabric-X and must be excluded from migration.
 var systemChaincodes = map[string]struct{}{
-	"lscc":        {},
-	"_lifecycle":  {},
-	"cscc":        {},
-	"qscc":        {},
-	"escc":        {},
-	"vscc":        {},
+	"lscc":       {},
+	"_lifecycle": {},
+	"cscc":       {},
+	"qscc":       {},
+	"escc":       {},
+	"vscc":       {},
 }
 
 // ShouldExcludeNamespace returns true if the given namespace should be

--- a/tools/fxmigrate/internal/snapshot/filter.go
+++ b/tools/fxmigrate/internal/snapshot/filter.go
@@ -1,0 +1,51 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package snapshot
+
+import "strings"
+
+// systemChaincodes is the set of Fabric system chaincode namespaces that
+// have no equivalent in Fabric-X and must be excluded from migration.
+var systemChaincodes = map[string]struct{}{
+	"lscc":        {},
+	"_lifecycle":  {},
+	"cscc":        {},
+	"qscc":        {},
+	"escc":        {},
+	"vscc":        {},
+}
+
+// ShouldExcludeNamespace returns true if the given namespace should be
+// dropped during migration.
+//
+// Excluded namespaces:
+//   - Fabric system chaincodes (lscc, _lifecycle, cscc, qscc, escc, vscc)
+//   - PDC hash namespaces  — keys starting with "$$h$$"
+//   - PDC private state    — keys starting with "$$p$$"
+//   - Implicit org collections — contain "$$"
+func ShouldExcludeNamespace(ns string) bool {
+	if _, ok := systemChaincodes[ns]; ok {
+		return true
+	}
+	// PDC hash and private state namespaces carry "$$" markers
+	if strings.Contains(ns, "$$") {
+		return true
+	}
+	return false
+}
+
+// ShouldExcludeKey returns true if an individual key within a namespace
+// should be dropped.
+//
+// Even in non-PDC namespaces, Fabric may embed PDC-related metadata keys.
+func ShouldExcludeKey(key string) bool {
+	// Fabric embeds PDC hash keys inside public namespaces using these prefixes
+	if strings.HasPrefix(key, "\x00collection") {
+		return true
+	}
+	return false
+}

--- a/tools/fxmigrate/internal/snapshot/filter_test.go
+++ b/tools/fxmigrate/internal/snapshot/filter_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package snapshot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldExcludeNamespace(t *testing.T) {
+	t.Parallel()
+
+	excluded := []string{
+		"lscc",
+		"_lifecycle",
+		"cscc",
+		"qscc",
+		"escc",
+		"vscc",
+		"$$h$$mycc",         // PDC hash namespace
+		"$$p$$mycc$$coll",   // PDC private state
+		"mycc$$implicitorg", // implicit org collection
+	}
+	for _, ns := range excluded {
+		require.True(t, ShouldExcludeNamespace(ns), "expected %q to be excluded", ns)
+	}
+
+	included := []string{
+		"mycc",
+		"token",
+		"basic",
+		"fabcar",
+	}
+	for _, ns := range included {
+		require.False(t, ShouldExcludeNamespace(ns), "expected %q to be included", ns)
+	}
+}
+
+func TestShouldExcludeKey(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, ShouldExcludeKey("\x00collectionMyPDC"))
+	require.False(t, ShouldExcludeKey("normalKey"))
+	require.False(t, ShouldExcludeKey("asset1"))
+}

--- a/tools/fxmigrate/internal/snapshot/manifest.go
+++ b/tools/fxmigrate/internal/snapshot/manifest.go
@@ -24,12 +24,12 @@ const signableMetadataFile = "_snapshot_signable_metadata.json"
 // Fabric writes this file at snapshot time so the receiver can verify
 // the snapshot files haven't been tampered with.
 type Manifest struct {
-	ChannelName     string            `json:"channel_name"`
-	LastBlockNumber uint64            `json:"last_block_number"`
-	LastBlockHash   string            `json:"last_block_hash"`
-	PreviousBlockHash string          `json:"previous_block_hash"`
-	StateDBType     string            `json:"state_db_type"`
-	FileHashes      map[string]string `json:"file_hashes"`
+	ChannelName       string            `json:"channel_name"`
+	LastBlockNumber   uint64            `json:"last_block_number"`
+	LastBlockHash     string            `json:"last_block_hash"`
+	PreviousBlockHash string            `json:"previous_block_hash"`
+	StateDBType       string            `json:"state_db_type"`
+	FileHashes        map[string]string `json:"file_hashes"`
 }
 
 // ReadManifest parses the signable metadata file from a snapshot directory.
@@ -78,7 +78,7 @@ func sha256File(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {

--- a/tools/fxmigrate/internal/snapshot/manifest.go
+++ b/tools/fxmigrate/internal/snapshot/manifest.go
@@ -1,0 +1,88 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package snapshot provides utilities for reading and validating Hyperledger Fabric
+// peer snapshot directories.
+package snapshot
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const signableMetadataFile = "_snapshot_signable_metadata.json"
+
+// Manifest holds the contents of _snapshot_signable_metadata.json.
+// Fabric writes this file at snapshot time so the receiver can verify
+// the snapshot files haven't been tampered with.
+type Manifest struct {
+	ChannelName     string            `json:"channel_name"`
+	LastBlockNumber uint64            `json:"last_block_number"`
+	LastBlockHash   string            `json:"last_block_hash"`
+	PreviousBlockHash string          `json:"previous_block_hash"`
+	StateDBType     string            `json:"state_db_type"`
+	FileHashes      map[string]string `json:"file_hashes"`
+}
+
+// ReadManifest parses the signable metadata file from a snapshot directory.
+func ReadManifest(snapshotDir string) (*Manifest, error) {
+	path := filepath.Join(snapshotDir, signableMetadataFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read %s: %w", signableMetadataFile, err)
+	}
+
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("cannot parse %s: %w", signableMetadataFile, err)
+	}
+
+	if m.ChannelName == "" {
+		return nil, fmt.Errorf("%s: channel_name is empty", signableMetadataFile)
+	}
+
+	return &m, nil
+}
+
+// VerifyChecksums recomputes SHA-256 hashes for every file listed in the manifest
+// and returns an error if any hash doesn't match.
+func VerifyChecksums(snapshotDir string, m *Manifest) error {
+	for filename, expectedHash := range m.FileHashes {
+		path := filepath.Join(snapshotDir, filename)
+		got, err := sha256File(path)
+		if err != nil {
+			return fmt.Errorf("cannot hash %s: %w", filename, err)
+		}
+		// Fabric stores hashes as hex strings, sometimes prefixed with "sha256:"
+		want := expectedHash
+		if len(want) > 7 && want[:7] == "sha256:" {
+			want = want[7:]
+		}
+		if got != want {
+			return fmt.Errorf("checksum mismatch for %s: got %s want %s", filename, got, want)
+		}
+	}
+	return nil
+}
+
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/tools/fxmigrate/internal/snapshot/manifest_test.go
+++ b/tools/fxmigrate/internal/snapshot/manifest_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package snapshot
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadManifest(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	meta := Manifest{
+		ChannelName:     "mychannel",
+		LastBlockNumber: 42,
+		StateDBType:     "goleveldb",
+		FileHashes:      map[string]string{},
+	}
+	data, err := json.Marshal(meta)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, signableMetadataFile), data, 0o600))
+
+	got, err := ReadManifest(dir)
+	require.NoError(t, err)
+	require.Equal(t, "mychannel", got.ChannelName)
+	require.Equal(t, uint64(42), got.LastBlockNumber)
+	require.Equal(t, "goleveldb", got.StateDBType)
+}
+
+func TestReadManifest_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := ReadManifest(t.TempDir())
+	require.Error(t, err)
+}
+
+func TestReadManifest_EmptyChannelName(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	meta := Manifest{LastBlockNumber: 1, StateDBType: "goleveldb", FileHashes: map[string]string{}}
+	data, err := json.Marshal(meta)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, signableMetadataFile), data, 0o600))
+
+	_, err = ReadManifest(dir)
+	require.ErrorContains(t, err, "channel_name is empty")
+}

--- a/tools/fxmigrate/internal/snapshot/reader.go
+++ b/tools/fxmigrate/internal/snapshot/reader.go
@@ -9,6 +9,7 @@ package snapshot
 import (
 	"bufio"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -31,10 +32,21 @@ type StateEntry struct {
 	Version uint64
 }
 
+// rawRecord is one decoded entry from public_state.data before filtering and
+// version conversion. namespace is empty when the on-disk record uses the
+// "same namespace as previous" marker (ns_len == 0).
+type rawRecord struct {
+	namespace string
+	key       string
+	value     []byte
+	blockNum  uint64
+	txNum     uint64
+}
+
 // DiscoverNamespaces scans the public state data file and returns the unique
 // set of namespaces present, excluding any that would be filtered out.
 func DiscoverNamespaces(snapshotDir string) ([]string, error) {
-	entries, err := readStateFile(snapshotDir, true)
+	entries, err := readStateFile(snapshotDir)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +66,7 @@ func DiscoverNamespaces(snapshotDir string) ([]string, error) {
 // ExportState reads the public state data file and returns all entries that
 // pass the namespace and key filters.
 func ExportState(snapshotDir string) ([]StateEntry, error) {
-	return readStateFile(snapshotDir, false)
+	return readStateFile(snapshotDir)
 }
 
 // readStateFile reads the Fabric snapshot public_state.data file.
@@ -68,100 +80,102 @@ func ExportState(snapshotDir string) ([]StateEntry, error) {
 //
 // A zero-length namespace signals a namespace boundary marker (same namespace
 // as the previous entry continues). We handle both forms.
-//
-// If discoverOnly is true the function returns entries with empty Value/Version
-// for speed — we only need namespace names.
-func readStateFile(snapshotDir string, discoverOnly bool) ([]StateEntry, error) {
+func readStateFile(snapshotDir string) ([]StateEntry, error) {
 	path := filepath.Join(snapshotDir, publicStateDataFile)
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open %s: %w", publicStateDataFile, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
-	r := bufio.NewReaderSize(f, 1<<20) // 1 MiB read buffer
+	r := bufio.NewReaderSize(f, 1<<20)
 
 	var (
-		entries      []StateEntry
-		currentNS    string
+		entries   []StateEntry
+		currentNS string
 	)
 
 	for {
-		// Read namespace length
-		nsLen, err := readUint32(r)
-		if err == io.EOF {
+		rec, rerr := readRawRecord(r)
+		if errors.Is(rerr, io.EOF) {
 			break
 		}
-		if err != nil {
-			return nil, fmt.Errorf("reading namespace length: %w", err)
+		if rerr != nil {
+			return nil, rerr
 		}
 
-		if nsLen > 0 {
-			nsBytes, err := readBytes(r, nsLen)
-			if err != nil {
-				return nil, fmt.Errorf("reading namespace: %w", err)
-			}
-			currentNS = string(nsBytes)
-		}
-		// nsLen == 0 means same namespace as previous entry
-
-		// Read key
-		keyLen, err := readUint32(r)
-		if err != nil {
-			return nil, fmt.Errorf("reading key length: %w", err)
-		}
-		keyBytes, err := readBytes(r, keyLen)
-		if err != nil {
-			return nil, fmt.Errorf("reading key: %w", err)
-		}
-		key := string(keyBytes)
-
-		// Read value
-		valLen, err := readUint32(r)
-		if err != nil {
-			return nil, fmt.Errorf("reading value length: %w", err)
-		}
-		valBytes, err := readBytes(r, valLen)
-		if err != nil {
-			return nil, fmt.Errorf("reading value: %w", err)
+		if rec.namespace != "" {
+			currentNS = rec.namespace
 		}
 
-		// Read version: (blockNum uint64, txNum uint64)
-		blockNum, err := readUint64(r)
-		if err != nil {
-			return nil, fmt.Errorf("reading block num: %w", err)
-		}
-		txNum, err := readUint64(r)
-		if err != nil {
-			return nil, fmt.Errorf("reading tx num: %w", err)
-		}
-
-		// Apply filters
-		if ShouldExcludeNamespace(currentNS) {
-			continue
-		}
-		if ShouldExcludeKey(key) {
-			continue
-		}
-		// Strip CouchDB internal metadata keys
-		if strings.HasPrefix(key, "~") {
+		if ShouldExcludeNamespace(currentNS) || ShouldExcludeKey(rec.key) || strings.HasPrefix(rec.key, "~") {
 			continue
 		}
 
-		entry := StateEntry{
+		entries = append(entries, StateEntry{
 			Namespace: currentNS,
-			Key:       key,
-		}
-		if !discoverOnly {
-			entry.Value = valBytes
-			// Convert (blockNum, txNum) → scalar Fabric-X version
-			entry.Version = (blockNum << 32) | (txNum & 0xFFFFFFFF)
-		}
-
-		entries = append(entries, entry)
+			Key:       rec.key,
+			Value:     rec.value,
+			Version:   (rec.blockNum << 32) | (rec.txNum & 0xFFFFFFFF),
+		})
 	}
 
 	return entries, nil
+}
+
+// readRawRecord decodes one entry from the public_state.data stream. It
+// returns io.EOF unwrapped when the stream is at a clean record boundary so
+// the caller can terminate the loop. Truncated records mid-entry surface as
+// wrapped errors.
+func readRawRecord(r *bufio.Reader) (*rawRecord, error) {
+	nsLen, err := readUint32(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var ns string
+	if nsLen > 0 {
+		nsBytes, berr := readBytes(r, nsLen)
+		if berr != nil {
+			return nil, fmt.Errorf("reading namespace: %w", berr)
+		}
+		ns = string(nsBytes)
+	}
+
+	keyBytes, err := readLenPrefixed(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading key: %w", err)
+	}
+
+	valBytes, err := readLenPrefixed(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading value: %w", err)
+	}
+
+	blockNum, err := readUint64(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading block num: %w", err)
+	}
+	txNum, err := readUint64(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading tx num: %w", err)
+	}
+
+	return &rawRecord{
+		namespace: ns,
+		key:       string(keyBytes),
+		value:     valBytes,
+		blockNum:  blockNum,
+		txNum:     txNum,
+	}, nil
+}
+
+func readLenPrefixed(r io.Reader) ([]byte, error) {
+	n, err := readUint32(r)
+	if err != nil {
+		return nil, err
+	}
+	return readBytes(r, n)
 }
 
 func readUint32(r io.Reader) (uint32, error) {

--- a/tools/fxmigrate/internal/snapshot/reader.go
+++ b/tools/fxmigrate/internal/snapshot/reader.go
@@ -1,0 +1,189 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package snapshot
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	publicStateDataFile = "public_state.data"
+)
+
+// StateEntry holds a single key-value pair from the public state, along
+// with its namespace and the converted Fabric-X version.
+type StateEntry struct {
+	Namespace string
+	Key       string
+	Value     []byte
+	// Version is converted from Fabric's (BlockNum, TxNum) pair to a
+	// Fabric-X scalar: (blockNum << 32) | txNum
+	Version uint64
+}
+
+// DiscoverNamespaces scans the public state data file and returns the unique
+// set of namespaces present, excluding any that would be filtered out.
+func DiscoverNamespaces(snapshotDir string) ([]string, error) {
+	entries, err := readStateFile(snapshotDir, true)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{})
+	for _, e := range entries {
+		seen[e.Namespace] = struct{}{}
+	}
+
+	out := make([]string, 0, len(seen))
+	for ns := range seen {
+		out = append(out, ns)
+	}
+	return out, nil
+}
+
+// ExportState reads the public state data file and returns all entries that
+// pass the namespace and key filters.
+func ExportState(snapshotDir string) ([]StateEntry, error) {
+	return readStateFile(snapshotDir, false)
+}
+
+// readStateFile reads the Fabric snapshot public_state.data file.
+//
+// Fabric writes this file using a simple length-delimited binary format:
+//
+//	[namespace_len uint32][namespace bytes]
+//	[key_len uint32][key bytes]
+//	[value_len uint32][value bytes]
+//	[block_num uint64][tx_num uint64]   <- version
+//
+// A zero-length namespace signals a namespace boundary marker (same namespace
+// as the previous entry continues). We handle both forms.
+//
+// If discoverOnly is true the function returns entries with empty Value/Version
+// for speed — we only need namespace names.
+func readStateFile(snapshotDir string, discoverOnly bool) ([]StateEntry, error) {
+	path := filepath.Join(snapshotDir, publicStateDataFile)
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open %s: %w", publicStateDataFile, err)
+	}
+	defer f.Close()
+
+	r := bufio.NewReaderSize(f, 1<<20) // 1 MiB read buffer
+
+	var (
+		entries      []StateEntry
+		currentNS    string
+	)
+
+	for {
+		// Read namespace length
+		nsLen, err := readUint32(r)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading namespace length: %w", err)
+		}
+
+		if nsLen > 0 {
+			nsBytes, err := readBytes(r, nsLen)
+			if err != nil {
+				return nil, fmt.Errorf("reading namespace: %w", err)
+			}
+			currentNS = string(nsBytes)
+		}
+		// nsLen == 0 means same namespace as previous entry
+
+		// Read key
+		keyLen, err := readUint32(r)
+		if err != nil {
+			return nil, fmt.Errorf("reading key length: %w", err)
+		}
+		keyBytes, err := readBytes(r, keyLen)
+		if err != nil {
+			return nil, fmt.Errorf("reading key: %w", err)
+		}
+		key := string(keyBytes)
+
+		// Read value
+		valLen, err := readUint32(r)
+		if err != nil {
+			return nil, fmt.Errorf("reading value length: %w", err)
+		}
+		valBytes, err := readBytes(r, valLen)
+		if err != nil {
+			return nil, fmt.Errorf("reading value: %w", err)
+		}
+
+		// Read version: (blockNum uint64, txNum uint64)
+		blockNum, err := readUint64(r)
+		if err != nil {
+			return nil, fmt.Errorf("reading block num: %w", err)
+		}
+		txNum, err := readUint64(r)
+		if err != nil {
+			return nil, fmt.Errorf("reading tx num: %w", err)
+		}
+
+		// Apply filters
+		if ShouldExcludeNamespace(currentNS) {
+			continue
+		}
+		if ShouldExcludeKey(key) {
+			continue
+		}
+		// Strip CouchDB internal metadata keys
+		if strings.HasPrefix(key, "~") {
+			continue
+		}
+
+		entry := StateEntry{
+			Namespace: currentNS,
+			Key:       key,
+		}
+		if !discoverOnly {
+			entry.Value = valBytes
+			// Convert (blockNum, txNum) → scalar Fabric-X version
+			entry.Version = (blockNum << 32) | (txNum & 0xFFFFFFFF)
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries, nil
+}
+
+func readUint32(r io.Reader) (uint32, error) {
+	var buf [4]byte
+	_, err := io.ReadFull(r, buf[:])
+	if err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint32(buf[:]), nil
+}
+
+func readUint64(r io.Reader) (uint64, error) {
+	var buf [8]byte
+	_, err := io.ReadFull(r, buf[:])
+	if err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint64(buf[:]), nil
+}
+
+func readBytes(r io.Reader, n uint32) ([]byte, error) {
+	buf := make([]byte, n)
+	_, err := io.ReadFull(r, buf)
+	return buf, err
+}

--- a/tools/fxmigrate/internal/snapshot/reader_test.go
+++ b/tools/fxmigrate/internal/snapshot/reader_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package snapshot
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// rawEntry is an unfiltered record written to the fixture file.
+type rawEntry struct {
+	namespace string // empty string means "reuse previous namespace" (ns_len=0)
+	key       string
+	value     []byte
+	blockNum  uint64
+	txNum     uint64
+}
+
+// buildStateFile writes a Fabric-format public_state.data fixture to dir.
+//
+// Fabric format per entry:
+//
+//	[ns_len uint32][ns bytes]      (ns_len=0 → same namespace as previous)
+//	[key_len uint32][key bytes]
+//	[val_len uint32][val bytes]
+//	[block_num uint64][tx_num uint64]
+func buildStateFile(t *testing.T, dir string, entries []rawEntry) {
+	t.Helper()
+	f, err := os.Create(filepath.Join(dir, publicStateDataFile))
+	require.NoError(t, err)
+	defer f.Close()
+
+	write32 := func(v uint32) {
+		var buf [4]byte
+		binary.BigEndian.PutUint32(buf[:], v)
+		_, err := f.Write(buf[:])
+		require.NoError(t, err)
+	}
+	write64 := func(v uint64) {
+		var buf [8]byte
+		binary.BigEndian.PutUint64(buf[:], v)
+		_, err := f.Write(buf[:])
+		require.NoError(t, err)
+	}
+	writeBytes := func(b []byte) {
+		write32(uint32(len(b)))
+		if len(b) > 0 {
+			_, err := f.Write(b)
+			require.NoError(t, err)
+		}
+	}
+
+	for _, e := range entries {
+		writeBytes([]byte(e.namespace)) // ns_len=0 when namespace==""
+		writeBytes([]byte(e.key))
+		writeBytes(e.value)
+		write64(e.blockNum)
+		write64(e.txNum)
+	}
+}
+
+func TestExportState_BasicEntries(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	buildStateFile(t, dir, []rawEntry{
+		{namespace: "mycc", key: "asset1", value: []byte("val1"), blockNum: 5, txNum: 2},
+		{namespace: "mycc", key: "asset2", value: []byte("val2"), blockNum: 10, txNum: 0},
+	})
+
+	entries, err := ExportState(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	require.Equal(t, "mycc", entries[0].Namespace)
+	require.Equal(t, "asset1", entries[0].Key)
+	require.Equal(t, []byte("val1"), entries[0].Value)
+	// version = (5 << 32) | 2
+	require.Equal(t, uint64(5)<<32|uint64(2), entries[0].Version)
+
+	require.Equal(t, "asset2", entries[1].Key)
+	require.Equal(t, uint64(10)<<32|uint64(0), entries[1].Version)
+}
+
+func TestExportState_SameNamespaceMarker(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Second entry uses ns_len=0 (empty namespace string → reuse previous)
+	buildStateFile(t, dir, []rawEntry{
+		{namespace: "mycc", key: "k1", value: []byte("v1"), blockNum: 1, txNum: 0},
+		{namespace: "", key: "k2", value: []byte("v2"), blockNum: 2, txNum: 0},
+	})
+
+	entries, err := ExportState(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	require.Equal(t, "mycc", entries[0].Namespace)
+	require.Equal(t, "mycc", entries[1].Namespace)
+}
+
+func TestExportState_ExcludesSystemNamespaces(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	buildStateFile(t, dir, []rawEntry{
+		{namespace: "lscc", key: "someCC", value: []byte("x"), blockNum: 1, txNum: 0},
+		{namespace: "_lifecycle", key: "def", value: []byte("y"), blockNum: 1, txNum: 1},
+		{namespace: "mycc", key: "asset1", value: []byte("z"), blockNum: 2, txNum: 0},
+	})
+
+	entries, err := ExportState(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, "mycc", entries[0].Namespace)
+}
+
+func TestExportState_ExcludesTildeKeys(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	buildStateFile(t, dir, []rawEntry{
+		{namespace: "mycc", key: "~couchdbMeta", value: []byte("meta"), blockNum: 1, txNum: 0},
+		{namespace: "mycc", key: "realKey", value: []byte("val"), blockNum: 1, txNum: 1},
+	})
+
+	entries, err := ExportState(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, "realKey", entries[0].Key)
+}
+
+func TestExportState_ExcludesPDCNamespaces(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	buildStateFile(t, dir, []rawEntry{
+		{namespace: "$$h$$mycc", key: "hashKey", value: []byte("h"), blockNum: 1, txNum: 0},
+		{namespace: "$$p$$mycc$$coll", key: "privKey", value: []byte("p"), blockNum: 1, txNum: 1},
+		{namespace: "mycc", key: "pub", value: []byte("v"), blockNum: 2, txNum: 0},
+	})
+
+	entries, err := ExportState(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, "mycc", entries[0].Namespace)
+}
+
+func TestExportState_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := ExportState(t.TempDir())
+	require.Error(t, err)
+	require.ErrorContains(t, err, publicStateDataFile)
+}
+
+func TestDiscoverNamespaces(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	buildStateFile(t, dir, []rawEntry{
+		{namespace: "mycc", key: "k1", value: []byte("v"), blockNum: 1, txNum: 0},
+		{namespace: "token", key: "k2", value: []byte("v"), blockNum: 1, txNum: 1},
+		{namespace: "mycc", key: "k3", value: []byte("v"), blockNum: 2, txNum: 0},
+		{namespace: "lscc", key: "k4", value: []byte("v"), blockNum: 2, txNum: 1}, // excluded
+	})
+
+	namespaces, err := DiscoverNamespaces(dir)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"mycc", "token"}, namespaces)
+}
+
+func TestDiscoverNamespaces_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := DiscoverNamespaces(t.TempDir())
+	require.Error(t, err)
+}

--- a/tools/fxmigrate/internal/snapshot/reader_test.go
+++ b/tools/fxmigrate/internal/snapshot/reader_test.go
@@ -8,6 +8,7 @@ package snapshot
 
 import (
 	"encoding/binary"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,7 +37,7 @@ func buildStateFile(t *testing.T, dir string, entries []rawEntry) {
 	t.Helper()
 	f, err := os.Create(filepath.Join(dir, publicStateDataFile))
 	require.NoError(t, err)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	write32 := func(v uint32) {
 		var buf [4]byte
@@ -51,6 +52,8 @@ func buildStateFile(t *testing.T, dir string, entries []rawEntry) {
 		require.NoError(t, err)
 	}
 	writeBytes := func(b []byte) {
+		require.LessOrEqual(t, len(b), math.MaxUint32)
+		//nolint:gosec // G115: length is bounds-checked above against math.MaxUint32.
 		write32(uint32(len(b)))
 		if len(b) > 0 {
 			_, err := f.Write(b)

--- a/tools/fxmigrate/main.go
+++ b/tools/fxmigrate/main.go
@@ -1,0 +1,28 @@
+// Copyright IBM Corp. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main provides the fxmigrate CLI tool for migrating Hyperledger Fabric
+// ledger state to Fabric-X.
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+
+	cli "github.com/hyperledger/fabric-x/tools/fxmigrate/internal/cli/v1"
+)
+
+func main() {
+	if err := run(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	return cli.NewRootCommand().ExecuteContext(ctx)
+}


### PR DESCRIPTION
Follow-up to #97 — implements the placeholder `verify` subcommand that was scaffolded there.

## What this adds

**`genesis.Reader`** (`internal/genesis/reader.go`)
The reader is the inverse of the existing `genesis.Writer`. It parses the same length-delimited binary format — `uint32`-prefixed JSON header followed by key/value/version triples — and exposes two functions: `ReadHeader` for a quick header-only check, and `ReadAll` for loading the full set of entries.

**`fxmigrate verify --genesis <file> --snapshot <dir>`**
Runs four integrity checks in sequence:

1. Parses the genesis-data file and prints the header metadata (namespace, source channel, block height, sha256).
2. Counts entries actually present in the file and compares against `header.EntryCount` — catches a truncated or partially-written output file before it ever reaches the committer.
3. Reads the source snapshot manifest and checks that the block height recorded in the genesis header matches.
4. Re-runs the same PDC/system-chaincode filtering over the snapshot and compares the filtered entry count against the genesis count — confirms nothing was silently dropped or duplicated during export.

This gives operators a way to sanity-check the artifact produced by `export` before handing it to the committer bootstrap, without needing the committer to be running at all.

## Tests

6 round-trip tests in `genesis/reader_test.go`: header round-trip, full entry round-trip, empty file, missing file (both `ReadHeader` and `ReadAll`), binary values.

## Related

- Epic: #21
- Export CLI: #97

Signed-off-by: Shridhar Panigrahi <sridharpanigrahi2006@gmail.com>