### PR TITLE
feat(fxconfig): parse namespace policies into human-readable strings

### DIFF
--- a/tools/fxconfig/internal/app/list.go
+++ b/tools/fxconfig/internal/app/list.go
@@ -8,12 +8,20 @@ package app
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
+	"strings"
+
+	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	msppb "github.com/hyperledger/fabric-protos-go-apiv2/msp"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 )
 
 // ListNamespaces queries the committer service for installed namespaces.
-// It connects to the query service, retrieves all namespace policies, and formats
-// the Output showing namespace names, versions, and policy data in hexadecimal.
+// It connects to the query service, retrieves all namespace policies, and returns
+// results with human-readable policy strings alongside the raw policy bytes.
 func (d *AdminApp) ListNamespaces(ctx context.Context) ([]NamespaceQueryResult, error) {
 	// get query service instance
 	qc, err := d.QueryProvider.Get()
@@ -31,10 +39,15 @@ func (d *AdminApp) ListNamespaces(ctx context.Context) ([]NamespaceQueryResult, 
 
 	results := make([]NamespaceQueryResult, len(res.GetPolicies()))
 	for i, p := range res.GetPolicies() {
+		policyStr, err := parsePolicy(p.GetPolicy())
+		if err != nil {
+			policyStr = fmt.Sprintf("%x", p.GetPolicy())
+		}
 		results[i] = NamespaceQueryResult{
-			NsID:    p.GetNamespace(),
-			Version: int(p.GetVersion()), //nolint:gosec
-			Policy:  p.GetPolicy(),
+			NsID:      p.GetNamespace(),
+			Version:   int(p.GetVersion()), //nolint:gosec
+			Policy:    p.GetPolicy(),
+			PolicyStr: policyStr,
 		}
 	}
 
@@ -43,30 +56,87 @@ func (d *AdminApp) ListNamespaces(ctx context.Context) ([]NamespaceQueryResult, 
 
 // NamespaceQueryResult represents a namespace retrieved from the query service.
 type NamespaceQueryResult struct {
-	NsID    string `json:"name" yaml:"name"`
-	Version int    `json:"version" yaml:"version"`
-	Policy  []byte `json:"policy" yaml:"policy"`
+	NsID      string `json:"name" yaml:"name"`
+	Version   int    `json:"version" yaml:"version"`
+	Policy    []byte `json:"policy" yaml:"policy"`
+	PolicyStr string `json:"policyStr" yaml:"policyStr"`
 }
 
-// parsePolicy extracts and formats policy information from serialized bytes.
-// Returns base64-encoded public key for threshold policies or string representation for MSP policies.
-// func parsePolicy(b []byte) string {
-//	var p applicationpb.NamespacePolicy
-//	if err := proto.Unmarshal(b, &p); err != nil {
-//		panic(err)
-//	}
-//
-//	switch r := p.Rule.(type) {
-//	case *applicationpb.NamespacePolicy_ThresholdRule:
-//		return base64.StdEncoding.EncodeToString(r.ThresholdRule.GetPublicKey())
-//	case *applicationpb.NamespacePolicy_MspRule:
-//		var en common.SignaturePolicy
-//		if err := proto.Unmarshal(r.MspRule, &en); err != nil {
-//			panic(err)
-//		}
-//		// TODO: some pretty print would be beautiful
-//		return en.String()
-//	default:
-//		return "error parsing policy"
-//	}
-// }
+// parsePolicy decodes raw NamespacePolicy bytes into a human-readable string.
+// For MSP policies it returns the DSL expression e.g. OR('Org1MSP.member', 'Org2MSP.member').
+// For threshold policies it returns the base64-encoded public key.
+// Falls back to hex on unmarshal errors.
+func parsePolicy(b []byte) (string, error) {
+	var nsPolicy applicationpb.NamespacePolicy
+	if err := proto.Unmarshal(b, &nsPolicy); err != nil {
+		return "", fmt.Errorf("failed to unmarshal policy: %w", err)
+	}
+
+	switch r := nsPolicy.Rule.(type) {
+	case *applicationpb.NamespacePolicy_ThresholdRule:
+		pubKey := base64.StdEncoding.EncodeToString(r.ThresholdRule.GetPublicKey())
+		return fmt.Sprintf("Threshold(ECDSA, %s)", pubKey), nil
+	case *applicationpb.NamespacePolicy_MspRule:
+		var env cb.SignaturePolicyEnvelope
+		if err := proto.Unmarshal(r.MspRule, &env); err != nil {
+			return "", fmt.Errorf("failed to unmarshal MSP rule: %w", err)
+		}
+		return signaturePolicyToString(env.GetRule(), env.GetIdentities())
+	default:
+		return fmt.Sprintf("%x", b), nil
+	}
+}
+
+// signaturePolicyToString recursively converts a SignaturePolicy tree into a DSL string.
+// AND/OR are derived from NOutOf: n==len(rules) → AND, n==1 → OR, otherwise OutOf(n,...).
+func signaturePolicyToString(rule *cb.SignaturePolicy, identities []*msppb.MSPPrincipal) (string, error) {
+	if rule == nil {
+		return "", nil
+	}
+
+	switch t := rule.Type.(type) {
+	case *cb.SignaturePolicy_SignedBy:
+		idx := t.SignedBy
+		if int(idx) >= len(identities) {
+			return "", fmt.Errorf("identity index %d out of range (have %d)", idx, len(identities))
+		}
+		s, err := principalToString(identities[idx])
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("'%s'", s), nil
+	case *cb.SignaturePolicy_NOutOf_:
+		n := t.NOutOf.GetN()
+		rules := t.NOutOf.GetRules()
+		parts := make([]string, 0, len(rules))
+		for _, r := range rules {
+			s, err := signaturePolicyToString(r, identities)
+			if err != nil {
+				return "", err
+			}
+			parts = append(parts, s)
+		}
+		switch {
+		case n == 1:
+			return fmt.Sprintf("OR(%s)", strings.Join(parts, ", ")), nil
+		case int(n) == len(rules):
+			return fmt.Sprintf("AND(%s)", strings.Join(parts, ", ")), nil
+		default:
+			return fmt.Sprintf("OutOf(%d, %s)", n, strings.Join(parts, ", ")), nil
+		}
+	default:
+		return fmt.Sprintf("%v", rule), nil
+	}
+}
+
+// principalToString converts an MSPPrincipal to a human-readable string like "Org1MSP.member".
+func principalToString(p *msppb.MSPPrincipal) (string, error) {
+	if p.GetPrincipalClassification() == msppb.MSPPrincipal_ROLE {
+		var role msppb.MSPRole
+		if err := proto.Unmarshal(p.GetPrincipal(), &role); err != nil {
+			return "", fmt.Errorf("failed to unmarshal MSP role: %w", err)
+		}
+		return fmt.Sprintf("%s.%s", role.GetMspIdentifier(), strings.ToLower(role.GetRole().String())), nil
+	}
+	return fmt.Sprintf("%x", p.GetPrincipal()), nil
+}

--- a/tools/fxconfig/internal/app/list_test.go
+++ b/tools/fxconfig/internal/app/list_test.go
@@ -13,8 +13,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	"github.com/hyperledger/fabric-x-common/common/policydsl"
+	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/adapters"
 	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/config"
 	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/provider"
@@ -89,4 +92,119 @@ func TestListNamespaces_QueryError(t *testing.T) {
 
 	_, err := a.ListNamespaces(t.Context())
 	require.Error(t, err)
+}
+
+func makeMspPolicyBytes(t *testing.T, expr string) []byte {
+	t.Helper()
+	env, err := policydsl.FromString(expr)
+	require.NoError(t, err)
+	nsPolicy := &applicationpb.NamespacePolicy{
+		Rule: &applicationpb.NamespacePolicy_MspRule{
+			MspRule: protoutil.MarshalOrPanic(env),
+		},
+	}
+	b, err := proto.Marshal(nsPolicy)
+	require.NoError(t, err)
+	return b
+}
+
+func TestParsePolicy_MspOR(t *testing.T) {
+	t.Parallel()
+
+	b := makeMspPolicyBytes(t, "OR('Org1MSP.member', 'Org2MSP.member')")
+	result, err := parsePolicy(b)
+	require.NoError(t, err)
+	require.Equal(t, "OR('Org1MSP.member', 'Org2MSP.member')", result)
+}
+
+func TestParsePolicy_MspAND(t *testing.T) {
+	t.Parallel()
+
+	b := makeMspPolicyBytes(t, "AND('Org1MSP.admin', 'Org2MSP.admin')")
+	result, err := parsePolicy(b)
+	require.NoError(t, err)
+	require.Equal(t, "AND('Org1MSP.admin', 'Org2MSP.admin')", result)
+}
+
+func TestParsePolicy_MspOutOfN(t *testing.T) {
+	t.Parallel()
+
+	// OutOf(2, ...) — 2-of-3
+	env, err := policydsl.FromString("OutOf(2, 'Org1MSP.member', 'Org2MSP.member', 'Org3MSP.member')")
+	require.NoError(t, err)
+	nsPolicy := &applicationpb.NamespacePolicy{
+		Rule: &applicationpb.NamespacePolicy_MspRule{
+			MspRule: protoutil.MarshalOrPanic(env),
+		},
+	}
+	b, err := proto.Marshal(nsPolicy)
+	require.NoError(t, err)
+
+	result, err := parsePolicy(b)
+	require.NoError(t, err)
+	require.Contains(t, result, "OutOf(2,")
+}
+
+func TestParsePolicy_Threshold(t *testing.T) {
+	t.Parallel()
+
+	nsPolicy := &applicationpb.NamespacePolicy{
+		Rule: &applicationpb.NamespacePolicy_ThresholdRule{
+			ThresholdRule: &applicationpb.ThresholdRule{
+				Scheme:    "ECDSA",
+				PublicKey: []byte("fakepublickey"),
+			},
+		},
+	}
+	b, err := proto.Marshal(nsPolicy)
+	require.NoError(t, err)
+
+	result, err := parsePolicy(b)
+	require.NoError(t, err)
+	require.Contains(t, result, "Threshold(ECDSA,")
+}
+
+func TestParsePolicy_InvalidBytes(t *testing.T) {
+	t.Parallel()
+
+	_, err := parsePolicy([]byte("not a proto"))
+	require.Error(t, err)
+}
+
+func TestListNamespaces_PolicyStrPopulated(t *testing.T) {
+	t.Parallel()
+
+	policyBytes := makeMspPolicyBytes(t, "OR('Org1MSP.member', 'Org2MSP.member')")
+	policies := &applicationpb.NamespacePolicies{
+		Policies: []*applicationpb.PolicyItem{
+			{Namespace: "ns1", Version: 1, Policy: policyBytes},
+		},
+	}
+	a := &AdminApp{
+		QueryProvider: makeQueryProvider(&mockQueryClient{policies: policies}, nil),
+	}
+
+	results, err := a.ListNamespaces(t.Context())
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, "OR('Org1MSP.member', 'Org2MSP.member')", results[0].PolicyStr)
+}
+
+func TestListNamespaces_PolicyStrFallbackOnBadBytes(t *testing.T) {
+	t.Parallel()
+
+	policies := &applicationpb.NamespacePolicies{
+		Policies: []*applicationpb.PolicyItem{
+			{Namespace: "ns1", Version: 1, Policy: []byte("bad")},
+		},
+	}
+	a := &AdminApp{
+		QueryProvider: makeQueryProvider(&mockQueryClient{policies: policies}, nil),
+	}
+
+	results, err := a.ListNamespaces(t.Context())
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	// falls back to hex
+	require.Equal(t, "626164", results[0].PolicyStr)
 }

--- a/tools/fxconfig/internal/cli/v1/namespace_list.go
+++ b/tools/fxconfig/internal/cli/v1/namespace_list.go
@@ -24,7 +24,7 @@ func newNsListCommand(ctx *CLIContext) *cobra.Command {
 For each namespace, displays:
   • Name (namespace identifier)
   • Version (current version number)
-  • Policy (endorsement policy in hexadecimal format)
+  • Policy (endorsement policy as a human-readable expression)
 
 Use this command to:
   • Verify namespace deployment
@@ -47,10 +47,10 @@ Examples:
 			}
 
 			// print namespace policy information to the Output writer.
-			// Each namespace is displayed with its index, name, version, and policy in hexadecimal format.
+			// Each namespace is displayed with its index, name, version, and human-readable policy.
 			ctx.Printer.Print(fmt.Sprintf("Installed namespaces (%d total):\n", len(result)))
 			for i, p := range result {
-				ctx.Printer.Print(fmt.Sprintf("%d) %v: version %d policy: %x\n", i, p.NsID, p.Version, p.Policy))
+				ctx.Printer.Print(fmt.Sprintf("%d) %v: version %d policy: %s\n", i, p.NsID, p.Version, p.PolicyStr))
 			}
 
 			return nil


### PR DESCRIPTION
#### Type of change
- New feature
- Improvement (improvement to code, performance, etc)

#### Description
 This PR implements that ```TODO: parsePolicy now unmarshals the NamespacePolicy proto``` and returns either a DSL expression like ```OR('Org1MSP.member', 'Org2MSP.member')``` for MSP policies (by recursively walking the ```NOutOf tree``` via signaturePolicyToString) or ```Threshold(ECDSA, <base64-key>)``` for threshold policies, falling back to hex only if decoding fails. 

```namespace_list.go``` is updated to print ```p.PolicyStr``` and ```list_test.go``` covers OR, AND, OutOf(n).

 Threshold, invalid bytes, and end-to-end policy string population.



#### Related issues
- Fixes: #195 
