### PR TITLE
fix(configtxlator): fix nil pointer deref in computeUpdt and add server graceful shutdown

### DIFF
--- a/tools/configtxlator/main.go
+++ b/tools/configtxlator/main.go
@@ -7,13 +7,17 @@ SPDX-License-Identifier: Apache-2.0
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"reflect"
 	"runtime"
+	"syscall"
+	"time"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/cockroachdb/errors"
@@ -114,20 +118,49 @@ func startServer(address string, cors []string) {
 		app.Fatalf("Could not bind to address '%s': %s", address, err)
 	}
 
+	router := rest.NewRouter()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.Handle("/", router)
+
+	var handler http.Handler = mux
+
 	if len(cors) > 0 {
 		origins := handlers.AllowedOrigins(cors)
 		// Note, configtxlator only exposes POST APIs for the time being, this
 		// list will need to be expanded if new non-POST APIs are added
-		methods := handlers.AllowedMethods([]string{http.MethodPost})
+		methods := handlers.AllowedMethods([]string{http.MethodPost, http.MethodGet})
 		headers := handlers.AllowedHeaders([]string{"Content-Type"})
+		handler = handlers.CORS(origins, methods, headers)(mux)
 		logger.Infof("Serving HTTP requests on %s with CORS %v", listener.Addr(), cors)
-		err = http.Serve(listener, handlers.CORS(origins, methods, headers)(rest.NewRouter()))
 	} else {
 		logger.Infof("Serving HTTP requests on %s", listener.Addr())
-		err = http.Serve(listener, rest.NewRouter())
 	}
 
-	app.Fatalf("Error starting server:[%s]\n", err)
+	srv := &http.Server{Handler: handler}
+
+	go func() {
+		if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+			logger.Fatalf("Error starting server: %s", err)
+		}
+	}()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	<-ctx.Done()
+	logger.Infof("Shutting down server gracefully...")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		logger.Fatalf("Server shutdown failed: %s", err)
+	}
+	logger.Infof("Server stopped")
 }
 
 func encodeProto(msgName string, input, output *os.File) error {
@@ -223,11 +256,11 @@ func computeUpdt(original, updated, output *os.File, channelID string) error {
 		return errors.Wrapf(err, "error computing config update")
 	}
 
-	cu.ChannelId = channelID
-
 	if cu == nil {
 		return errors.New("error marshaling computed config update: proto: Marshal called with nil")
 	}
+
+	cu.ChannelId = channelID
 	outBytes, err := proto.Marshal(cu)
 	if err != nil {
 		return errors.Wrapf(err, "error marshaling computed config update")

--- a/tools/configtxlator/main_test.go
+++ b/tools/configtxlator/main_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"testing"
+)
+
+// This is a minimal placeholder test file to cover computeUpdt edge cases.
+// It ensures that calling computeUpdt with nil inputs does not panic but returns an error.
+func TestComputeUpdt_NilPointerDereference(t *testing.T) {
+	err := computeUpdt(nil, nil, nil, "test-channel")
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
+}


### PR DESCRIPTION

## Type of change
- [x] Bug fix
- [x] Improvement (improvement to code, performance, etc)
- [x] Test update

## Description
This PR addresses two critical issues in `configtxlator`:

### Nil Pointer Dereference in `computeUpdt`
Fixed a bug where `cu.ChannelId = channelID` was assigned before checking whether `cu == nil`. When `update.Compute()` returned `nil`, this caused a nil pointer dereference panic. The nil check has now been reordered to occur before the assignment.

### Missing Graceful Shutdown in REST Server
The `configtxlator` server initialized by `startServer()` previously blocked on `http.Serve` indefinitely with no signal handling or cancellation. It now uses an `http.Server` with signal-based graceful shutdown handling. Additionally, a `/healthz` endpoint has been exposed.

Fixes: #200 