### PR TITLE
fix(fxconfig): print TxID when using --wait on namespace create/update

### DIFF
--- a/tools/fxconfig/internal/app/deploy.go
+++ b/tools/fxconfig/internal/app/deploy.go
@@ -86,11 +86,11 @@ func (d *AdminApp) DeployNamespace(
 		if err != nil {
 			return nil, UnknownStatus, err
 		}
-		return nil, status, nil
+		return &DeployNamespaceOutput{TxID: out.TxID}, status, nil
 	}
 	if err := d.SubmitTransaction(ctx, out.TxID, out.Tx); err != nil {
 		return nil, UnknownStatus, err
 	}
 
-	return nil, UnknownStatus, nil
+	return &DeployNamespaceOutput{TxID: out.TxID}, UnknownStatus, nil
 }

--- a/tools/fxconfig/internal/app/deploy_test.go
+++ b/tools/fxconfig/internal/app/deploy_test.go
@@ -166,7 +166,8 @@ func TestDeployNamespace_EndorseAndSubmit(t *testing.T) {
 
 	out, status, err := a.DeployNamespace(t.Context(), input)
 	require.NoError(t, err)
-	require.Nil(t, out)
+	require.NotNil(t, out)
+	require.NotEmpty(t, out.TxID)
 	require.Equal(t, UnknownStatus, status)
 }
 
@@ -205,7 +206,8 @@ func TestDeployNamespace_EndorseAndSubmitWithWait(t *testing.T) {
 
 	out, status, err := a.DeployNamespace(t.Context(), input)
 	require.NoError(t, err)
-	require.Nil(t, out)
+	require.NotNil(t, out)
+	require.NotEmpty(t, out.TxID)
 	require.Equal(t, expectedStatus, status)
 }
 

--- a/tools/fxconfig/internal/cli/v1/namespace_create.go
+++ b/tools/fxconfig/internal/cli/v1/namespace_create.go
@@ -78,7 +78,11 @@ Examples:
 				return err
 			}
 
-			if res == nil {
+			if res != nil && res.TxID != "" {
+				ctx.Printer.Print(fmt.Sprintf("Transaction ID: %s", res.TxID))
+			}
+
+			if res == nil || res.Tx == nil {
 				ctx.Printer.Print(
 					fmt.Sprintf("Transaction status: %s", committerpb.Status_name[int32(status)]), //nolint:gosec
 				)

--- a/tools/fxconfig/internal/cli/v1/namespace_create_test.go
+++ b/tools/fxconfig/internal/cli/v1/namespace_create_test.go
@@ -41,7 +41,7 @@ func TestNewCreateCommandRun_TxReturned(t *testing.T) {
 	mockApp := &testApp{}
 	deployOut := &app.DeployNamespaceOutput{
 		TxID: "tx-123",
-		Tx:   &applicationpb.Tx{},
+		Tx:   nil,
 	}
 	mockApp.On("DeployNamespace", mock.Anything, mock.Anything).Return(deployOut, app.UnknownStatus, nil)
 
@@ -60,7 +60,7 @@ func TestNewCreateCommandRun_TxReturned(t *testing.T) {
 	err := cmd.RunE(cmd, []string{"my-namespace"})
 
 	require.NoError(t, err)
-	require.Contains(t, cmdOut.String(), "tx-123")
+	require.Contains(t, printerOut.String(), "tx-123")
 	mockApp.AssertExpectations(t)
 }
 
@@ -68,7 +68,10 @@ func TestNewCreateCommandRun_NoTx(t *testing.T) {
 	t.Parallel()
 
 	mockApp := &testApp{}
-	mockApp.On("DeployNamespace", mock.Anything, mock.Anything).Return(nil, app.UnknownStatus, nil)
+	deployOut := &app.DeployNamespaceOutput{
+		TxID: "tx-456",
+	}
+	mockApp.On("DeployNamespace", mock.Anything, mock.Anything).Return(deployOut, app.UnknownStatus, nil)
 
 	var printerOut, printerErr bytes.Buffer
 	printer := cliio.NewCLIPrinter(&printerOut, &printerErr, cliio.FormatTable)
@@ -81,6 +84,7 @@ func TestNewCreateCommandRun_NoTx(t *testing.T) {
 	err := cmd.RunE(cmd, []string{"my-namespace"})
 
 	require.NoError(t, err)
+	require.Contains(t, printerOut.String(), "tx-456")
 	require.Contains(t, printerOut.String(), "Transaction status: STATUS_UNSPECIFIED")
 	mockApp.AssertExpectations(t)
 }

--- a/tools/fxconfig/internal/cli/v1/namespace_update.go
+++ b/tools/fxconfig/internal/cli/v1/namespace_update.go
@@ -77,7 +77,11 @@ Examples:
 				return err
 			}
 
-			if res == nil {
+			if res != nil && res.TxID != "" {
+				ctx.Printer.Print(fmt.Sprintf("Transaction ID: %s", res.TxID))
+			}
+
+			if res == nil || res.Tx == nil {
 				ctx.Printer.Print(
 					fmt.Sprintf("Transaction status: %s", committerpb.Status_name[int32(status)]), //nolint:gosec
 				)


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

When you run `fxconfig namespace create` or `fxconfig namespace update` with
`--endorse --submit --wait`, the transaction goes through successfully but the
TxID is never shown to the user. It was being discarded in `deploy.go` before
it could reach the CLI output.

This means after waiting for a transaction to commit, you only see:

    Transaction status: COMMITTED

With no way to know which transaction that was or reference it later.

The fix is straightforward — instead of returning nil from DeployNamespace after
the wait, we now return the TxID so both CLI handlers can print it alongside
the status:

    Transaction ID: <txid>
    Transaction status: COMMITTED

#### Additional details (Optional)

Three files changed:
- `deploy.go` — stop discarding the TxID on the wait and submit paths
- `namespace_create.go` — print TxID before the status message
- `namespace_update.go` — same fix

#### Related issues

Fixes #197