### PR TITLE
fix(fxconfig/provider): retry on transient initialization errors

### DIFF
--- a/tools/fxconfig/internal/provider/provider.go
+++ b/tools/fxconfig/internal/provider/provider.go
@@ -14,12 +14,14 @@ import (
 )
 
 // Provider manages lazy initialization of service instances with validation support.
-// It ensures thread-safe, single initialization using sync.Once.
+// It uses a mutex-guarded initialization that retries on transient errors while caching
+// permanent failures (like validation errors).
 type Provider[T any, K Validatable] struct {
-	once              sync.Once
+	mu                sync.Mutex
 	factory           func(cfg K) (T, error)
 	instance          T
 	err               error
+	initialized       bool
 	cfg               K
 	validationContext validation.Context
 }
@@ -39,15 +41,26 @@ func New[T any, K Validatable](
 }
 
 // Get returns the service instance, validating the config and initializing the service instance on first call.
-// Subsequent calls return the cached instance. Thread-safe.
+// Subsequent calls return the cached instance if initialization succeeded or failed with a permanent error.
+// If initialization fails with a transient error, subsequent calls will retry. Thread-safe.
 func (p *Provider[T, K]) Get() (T, error) {
-	p.once.Do(func() {
-		if err := p.cfg.Validate(p.validationContext); err != nil {
-			p.err = err
-			return
-		}
-		p.instance, p.err = p.factory(p.cfg)
-	})
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.initialized {
+		return p.instance, p.err
+	}
+
+	if err := p.cfg.Validate(p.validationContext); err != nil {
+		p.err = err
+		p.initialized = true
+		return p.instance, p.err
+	}
+
+	p.instance, p.err = p.factory(p.cfg)
+	if p.err == nil {
+		p.initialized = true
+	}
 	return p.instance, p.err
 }
 

--- a/tools/fxconfig/internal/provider/provider_test.go
+++ b/tools/fxconfig/internal/provider/provider_test.go
@@ -85,8 +85,45 @@ func TestProvider_Get_LazyInitialization(t *testing.T) {
 	require.NoError(t, err2)
 	require.NoError(t, err3)
 
-	// Validation and factory should only be called once due to sync.Once
+	// Validation and factory should only be called once
 	require.Equal(t, 1, callCount)
+}
+
+func TestProvider_Get_RetryOnTransientError(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	expectedErr := errors.New("transient error")
+	cfg := &mockConfig{}
+	factory := func(*mockConfig) (*mockService, error) {
+		callCount++
+		if callCount == 1 {
+			return nil, expectedErr
+		}
+		return &mockService{value: "test"}, nil
+	}
+
+	p := provider.New(factory, cfg, validation.Context{})
+
+	// First call fails with transient error
+	svc1, err1 := p.Get()
+	require.Nil(t, svc1)
+	require.ErrorIs(t, err1, expectedErr)
+
+	// Second call should retry and succeed
+	svc2, err2 := p.Get()
+	require.NoError(t, err2)
+	require.NotNil(t, svc2)
+	require.Equal(t, "test", svc2.value)
+
+	// Third call should return cached success
+	svc3, err3 := p.Get()
+	require.NoError(t, err3)
+	require.NotNil(t, svc3)
+	require.Equal(t, "test", svc3.value)
+
+	// Factory should be called exactly twice
+	require.Equal(t, 2, callCount)
 }
 
 func TestProvider_Get_ValidationError(t *testing.T) {


### PR DESCRIPTION
## Description

This PR fixes a bug in `fxconfig/provider` where `sync.Once` permanently cached initialization failures, preventing the application from recovering from transient errors (such as temporary DNS failures, network partitions, or an orderer not yet being ready). 

With `sync.Once`, if the first `Get()` call failed, all subsequent calls returned the exact same stale error forever, requiring a full process restart to recover.

### Changes Made
* Replaced `sync.Once` with a `sync.Mutex`-guarded lazy initialization block in `Provider.Get()`.
* If the factory function returns an error (transient), the error is returned but the state is *not* marked as initialized, allowing subsequent `Get()` calls to retry.
* Permanent errors (e.g., config validation failures via `Validate()`) are still permanently cached to avoid unnecessary re-validation on every call.
* Added `TestProvider_Get_RetryOnTransientError` unit tests to ensure that transient failures correctly trigger a retry on the next call, and that successful results are cached thereafter.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- `go test -v ./tools/fxconfig/internal/provider/...` passes cleanly.
- Added explicit test coverage for the transient error retry behavior.


FIXES: #204 