### PR TITLE
fix(configtxlator): mark --original and --updated flags as required and add nil guards

### DIFF
--- a/tools/configtxlator/main.go
+++ b/tools/configtxlator/main.go
@@ -61,8 +61,8 @@ var (
 	protoDecodeDest   = protoDecode.Flag("output", "A file to write the JSON document to.").Default(os.Stdout.Name()).OpenFile(os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 
 	computeUpdate          = app.Command("compute_update", "Takes two marshaled common.Config messages and computes the config update which transitions between the two.")
-	computeUpdateOriginal  = computeUpdate.Flag("original", "The original config message.").File()
-	computeUpdateUpdated   = computeUpdate.Flag("updated", "The updated config message.").File()
+	computeUpdateOriginal  = computeUpdate.Flag("original", "The original config message.").Required().File()
+	computeUpdateUpdated   = computeUpdate.Flag("updated", "The updated config message.").Required().File()
 	computeUpdateChannelID = computeUpdate.Flag("channel_id", "The name of the channel for this update.").Required().String()
 	computeUpdateDest      = computeUpdate.Flag("output", "A file to write the JSON document to.").Default(os.Stdout.Name()).OpenFile(os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 
@@ -79,6 +79,12 @@ func main() {
 		startServer(fmt.Sprintf("%s:%d", *hostname, *port), *cors)
 	// "proto_encode" command
 	case protoEncode.FullCommand():
+		if *protoEncodeSource == nil {
+			app.Fatalf("Error: input file is required")
+		}
+		if *protoEncodeDest == nil {
+			app.Fatalf("Error: output file is required")
+		}
 		defer (*protoEncodeSource).Close()
 		defer (*protoEncodeDest).Close()
 		err := encodeProto(*protoEncodeType, *protoEncodeSource, *protoEncodeDest)
@@ -86,6 +92,12 @@ func main() {
 			app.Fatalf("Error decoding: %s", err)
 		}
 	case protoDecode.FullCommand():
+		if *protoDecodeSource == nil {
+			app.Fatalf("Error: input file is required")
+		}
+		if *protoDecodeDest == nil {
+			app.Fatalf("Error: output file is required")
+		}
 		defer (*protoDecodeSource).Close()
 		defer (*protoDecodeDest).Close()
 		err := decodeProto(*protoDecodeType, *protoDecodeSource, *protoDecodeDest)
@@ -93,6 +105,15 @@ func main() {
 			app.Fatalf("Error decoding: %s", err)
 		}
 	case computeUpdate.FullCommand():
+		if *computeUpdateOriginal == nil {
+			app.Fatalf("Error: original config file is required")
+		}
+		if *computeUpdateUpdated == nil {
+			app.Fatalf("Error: updated config file is required")
+		}
+		if *computeUpdateDest == nil {
+			app.Fatalf("Error: output file is required")
+		}
 		defer (*computeUpdateOriginal).Close()
 		defer (*computeUpdateUpdated).Close()
 		defer (*computeUpdateDest).Close()
@@ -196,6 +217,16 @@ func decodeProto(msgName string, input, output *os.File) error {
 }
 
 func computeUpdt(original, updated, output *os.File, channelID string) error {
+	if original == nil {
+		return errors.New("original config file is required")
+	}
+	if updated == nil {
+		return errors.New("updated config file is required")
+	}
+	if output == nil {
+		return errors.New("output file is required")
+	}
+
 	origIn, err := io.ReadAll(original)
 	if err != nil {
 		return errors.Wrapf(err, "error reading original config")

--- a/tools/configtxlator/main_test.go
+++ b/tools/configtxlator/main_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// resetApp reinitializes the kingpin app to avoid state leaks between tests.
+// It sets a terminate handler that panics instead of calling os.Exit, allowing
+// the test's deferred recover() to catch the termination.
+func resetApp(t *testing.T) {
+	t.Helper()
+	app.Terminate(func(_ int) {
+		panic("kingpin-exit")
+	})
+}
+
+func TestComputeUpdateMissingOriginalFlag(t *testing.T) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+
+	resetApp(t)
+
+	os.Args = []string{
+		"configtxlator",
+		"compute_update",
+		"--channel_id=testchannel",
+	}
+
+	panicked := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		_, err := app.Parse(os.Args[1:])
+		if err != nil {
+			// Kingpin returns an error when required flags are missing.
+			// This is the expected path — it means .Required() is working.
+			t.Logf("app.Parse correctly returned error: %v", err)
+			return
+		}
+		t.Error("expected app.Parse to return an error when --original and --updated are missing")
+	}()
+
+	if panicked {
+		// Kingpin called Terminate, which we turned into a panic. That also means
+		// it detected the missing required flag. Both paths are acceptable.
+		t.Log("kingpin terminated as expected for missing required flags")
+	}
+}
+
+func TestComputeUpdateWithValidFlags(t *testing.T) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+
+	resetApp(t)
+
+	origFile := filepath.Join(t.TempDir(), "original.pb")
+	updatedFile := filepath.Join(t.TempDir(), "updated.pb")
+	outFile := filepath.Join(t.TempDir(), "output.pb")
+
+	// Write empty files so kingpin can open them.
+	os.WriteFile(origFile, []byte{}, 0644)
+	os.WriteFile(updatedFile, []byte{}, 0644)
+
+	os.Args = []string{
+		"configtxlator",
+		"compute_update",
+		"--channel_id=testchannel",
+		"--original=" + origFile,
+		"--updated=" + updatedFile,
+		"--output=" + outFile,
+	}
+
+	cmd, err := app.Parse(os.Args[1:])
+	if err != nil {
+		t.Fatalf("app.Parse failed unexpectedly: %v", err)
+	}
+
+	if cmd != computeUpdate.FullCommand() {
+		t.Fatalf("expected command %q, got %q", computeUpdate.FullCommand(), cmd)
+	}
+
+	// Verify file handles are non-nil — this is the core assertion.
+	// Before this fix, they would be nil and the deferred Close() would panic.
+	if *computeUpdateOriginal == nil {
+		t.Fatal("computeUpdateOriginal file handle is nil")
+	}
+	if *computeUpdateUpdated == nil {
+		t.Fatal("computeUpdateUpdated file handle is nil")
+	}
+	if *computeUpdateDest == nil {
+		t.Fatal("computeUpdateDest file handle is nil")
+	}
+
+	// Clean up file handles opened by kingpin.
+	(*computeUpdateOriginal).Close()
+	(*computeUpdateUpdated).Close()
+	(*computeUpdateDest).Close()
+}
+
+func TestComputeUpdateNilGuardsPreventPanic(t *testing.T) {
+	// Directly call computeUpdt with nil to verify it returns an error
+	// rather than panicking with a nil pointer dereference.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("computeUpdt panicked with nil inputs: %v", r)
+		}
+	}()
+
+	err := computeUpdt(nil, nil, nil, "testchannel")
+	if err == nil {
+		t.Fatal("expected error from computeUpdt with nil inputs, got nil")
+	}
+	t.Logf("computeUpdt correctly returned error: %v", err)
+}


### PR DESCRIPTION

the file pointers remained `nil`, and the deferred `Close()` calls caused a nil pointer panic instead of a helpful error message.

### Changes Made

**`tools/configtxlator/main.go`:**
- Added `.Required()` to the `--original` and `--updated` flag definitions so kingpin enforces them at parse time with a clear error message.
- Added `nil` guards before all `defer Close()` calls in the `proto_encode`, `proto_decode`, and `compute_update` command handlers to prevent nil pointer dereferences.
- Added `nil` guards at the top of the `computeUpdt()` function to return a descriptive error instead of panicking.

**`tools/configtxlator/main_test.go` [NEW]:**
- `TestComputeUpdateMissingOriginalFlag`: Verifies kingpin rejects the command when required flags are omitted.
- `TestComputeUpdateWithValidFlags`: Verifies file handles are non-nil when all flags are properly provided.
- `TestComputeUpdateNilGuardsPreventPanic`: Calls `computeUpdt(nil, nil, nil, ...)` directly and verifies it returns an error instead of panicking.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- `go test -v ./tools/configtxlator` — all 3 tests pass.

Fixes: #212