### PR TITLE
fix(fxconfig)!: enable TLS by default to prevent plaintext fallback vulnerability

### DIFF
--- a/tools/fxconfig/docs/README.md
+++ b/tools/fxconfig/docs/README.md
@@ -141,6 +141,14 @@ notifications:
     enabled: false
 ```
 
+> **TLS is enabled by default (secure-by-default).** Each service (`orderer`, `queries`, `notifications`) must therefore either:
+> - provide at least `tls.rootCerts` (server-side TLS) — and additionally `tls.clientCert` / `tls.clientKey` for mutual TLS; or
+> - explicitly opt out with `tls.enabled: false`.
+>
+> A service with `tls.enabled: true` but no `rootCerts` will fail to load with `rootCertPaths must not be empty`.
+>
+> **Breaking change (v0.4.0+):** prior versions defaulted to `tls.enabled: false`. Configs upgraded from older versions that omit the `tls` section will now attempt TLS — set `tls.enabled: false` per service to keep the previous plaintext behavior.
+
 ### TLS Configuration
 
 - **No TLS**: `enabled: false` or all TLS fields empty

--- a/tools/fxconfig/integration/helpers_test.go
+++ b/tools/fxconfig/integration/helpers_test.go
@@ -140,15 +140,21 @@ orderer:
   address: ` + endpoints["orderer"] + `
   channel: ` + channelID + `
   connectionTimeout: 30s
+  tls:
+    enabled: false
 
 queries:
   address: ` + endpoints["query"] + `
   connectionTimeout: 20s
+  tls:
+    enabled: false
 
 notifications:
   address: ` + endpoints["sidecar"] + `
   connectionTimeout: 15s
   waitingTimeout: 15s
+  tls:
+    enabled: false
 `
 	err := os.WriteFile(configPath, []byte(configContent), 0o600)
 	require.NoError(tb, err)

--- a/tools/fxconfig/internal/cli/v1/root.go
+++ b/tools/fxconfig/internal/cli/v1/root.go
@@ -9,12 +9,15 @@ SPDX-License-Identifier: Apache-2.0
 package v1
 
 import (
+	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	"github.com/spf13/cobra"
 
 	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/app"
 	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/cli/v1/cliio"
 	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/config"
 )
+
+var rootLogger = flogging.MustGetLogger("root")
 
 // NewRootCommand constructs and returns the root command for fxconfig.
 // It sets up configuration loading, flag registration, and all subcommands.
@@ -48,6 +51,23 @@ Configuration can be provided via:
 			cfg, err := config.Load(opts...)
 			if err != nil {
 				return err
+			}
+
+			// Warn if TLS is disabled for any service (secure-by-default).
+			// Naming the services keeps the warning actionable.
+			var insecure []string
+			if !cfg.Orderer.TLS.IsEnabled() {
+				insecure = append(insecure, "orderer")
+			}
+			if !cfg.Queries.TLS.IsEnabled() {
+				insecure = append(insecure, "queries")
+			}
+			if !cfg.Notifications.TLS.IsEnabled() {
+				insecure = append(insecure, "notifications")
+			}
+			if len(insecure) > 0 {
+				rootLogger.Warnf("TLS is disabled for: %v — connections to these services "+
+					"will be unencrypted. This is insecure and not recommended for production.", insecure)
 			}
 
 			// set our config and printer in our context

--- a/tools/fxconfig/internal/config/config.go
+++ b/tools/fxconfig/internal/config/config.go
@@ -60,7 +60,7 @@ type MSPConfig struct {
 //
 //nolint:revive,lll
 type TLSConfig struct {
-	Enabled            *bool    `mapstructure:"enabled" yaml:"enabled,omitempty" desc:"Enable/disable TLS" default:"false"`
+	Enabled            *bool    `mapstructure:"enabled" yaml:"enabled,omitempty" desc:"Enable/disable TLS" default:"true"`
 	ClientKeyPath      string   `mapstructure:"clientKey" yaml:"clientKey,omitempty" desc:"Path to TLS client private key"`
 	ClientCertPath     string   `mapstructure:"clientCert" yaml:"clientCert,omitempty" desc:"Path to TLS client certificate"`
 	RootCertPaths      []string `mapstructure:"rootCerts" yaml:"rootCerts,omitempty" desc:"Paths to TLS root certificates"`
@@ -68,10 +68,10 @@ type TLSConfig struct {
 }
 
 // Normalize ensures the TLS config has an explicit enabled flag.
-// Sets enabled to false if not specified.
+// Sets enabled to true if not specified.
 func (c *TLSConfig) Normalize() {
 	if c.Enabled == nil {
-		enabled := false
+		enabled := true
 		c.Enabled = &enabled
 	}
 }

--- a/tools/fxconfig/internal/config/config_test.go
+++ b/tools/fxconfig/internal/config/config_test.go
@@ -44,7 +44,7 @@ func TestTLSConfig_Normalize(t *testing.T) {
 		cfg      *TLSConfig
 		wantBool bool
 	}{
-		{"nil Enabled", &TLSConfig{}, false},
+		{"nil Enabled", &TLSConfig{}, true},
 		{"already false", &TLSConfig{Enabled: boolPtr(false)}, false},
 		{"already true", &TLSConfig{Enabled: boolPtr(true)}, true},
 	}

--- a/tools/fxconfig/internal/config/load_test.go
+++ b/tools/fxconfig/internal/config/load_test.go
@@ -423,6 +423,8 @@ queries:
 
 notifications:
   address: localhost:7002
+  tls:
+    enabled: false
 `
 	err := os.WriteFile(configPath, []byte(configContent), 0o600)
 	require.NoError(t, err)
@@ -434,8 +436,43 @@ notifications:
 
 	assert.True(t, cfg.Orderer.TLS.IsEnabled())
 	assert.Equal(t, []string{"/path/to/ca.pem"}, cfg.Orderer.TLS.RootCertPaths)
-	assert.False(t, cfg.Queries.TLS.IsEnabled())
-	assert.False(t, cfg.Notifications.TLS.IsEnabled())
+	assert.False(t, cfg.Queries.TLS.IsEnabled(), "Queries explicitly has enabled: false in config")
+	assert.False(t, cfg.Notifications.TLS.IsEnabled(), "Notifications explicitly has enabled: false in config")
+}
+
+// TestLoad_TLSEnabledByDefault verifies that TLS is enabled by default when
+// no explicit tls.enabled is specified. This is the secure-by-default behavior.
+func TestLoad_TLSEnabledByDefault(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	configContent := `
+msp:
+  localMspID: TestMSP
+  configPath: /tmp/msp
+
+orderer:
+  address: localhost:7050
+
+queries:
+  address: localhost:7001
+
+notifications:
+  address: localhost:7002
+`
+	err := os.WriteFile(configPath, []byte(configContent), 0o600)
+	require.NoError(t, err)
+
+	cfg, err := Load(WithConfigFile(configPath))
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	// TLS should be enabled by default when not explicitly specified
+	assert.True(t, cfg.Orderer.TLS.IsEnabled(), "Orderer should have TLS enabled by default")
+	assert.True(t, cfg.Queries.TLS.IsEnabled(), "Queries should have TLS enabled by default")
+	assert.True(t, cfg.Notifications.TLS.IsEnabled(), "Notifications should have TLS enabled by default")
 }
 
 func TestLoad_LoggingConfig(t *testing.T) {


### PR DESCRIPTION
 ## Summary

  Enable TLS by default across all service configurations (orderer, queries, notifications). Previously TLS was disabled by default.

  ## Breaking Change 

  **TLS is now enabled by default.** 

  If you upgrade to this version and don't have TLS configured, you may see:
  rootCertPaths must not be empty

  **New users** must either:
  - Configure TLS with `rootCerts`, or
  - Explicitly set `tls.enabled: false`

  **Existing users** can add `tls.enabled: false` to restore previous behavior.                                                                                                            
   
  ## Changes                                                                                                                                                                               
                  
  - TLS now defaults to `enabled: true` instead of `false`
  - `Normalize()` sets `Enabled=true` when nil
  - TLS warning moved to config load time (single centralized warning instead of per-client)
  - Integration tests updated with explicit `tls.enabled: false` (testcontainers use `--insecure` flag)
  - Added `assert.False` message for Queries TLS assertion for consistency

  ## Migration

  **Enable TLS (recommended for production):**
  ```yaml
  tls:
    enabled: true
    rootCerts:
      - /path/to/ca.crt

  Disable TLS (not recommended for production):
  tls:
    enabled: false
```
 Fixes #108
  Test Plan

  - Unit tests pass
  - Integration tests pass 