### PR TITLE
fix(fxconfig): defer CloseSend on broadcast stream to prevent connection leak (#209)

### DIFF
--- a/tools/fxconfig/internal/client/orderer.go
+++ b/tools/fxconfig/internal/client/orderer.go
@@ -83,6 +83,10 @@ func (oc *OrdererClient) send(ctx context.Context, env *cb.Envelope) error {
 	if err != nil {
 		return err
 	}
+	// Signal end-of-send so the orderer can terminate the stream and the
+	// underlying connection isn't held until ctx cancellation. Without
+	// this each error path leaked the broadcast stream (#209).
+	defer func() { _ = abc.CloseSend() }()
 
 	err = abc.Send(env)
 	if err != nil {


### PR DESCRIPTION
Fixes #209. `OrdererClient.send()` opens a gRPC broadcast stream via `oc.client.Broadcast(ctx)` but never calls `CloseSend()`. On every error path (`Send` failure, `Recv` failure, non-SUCCESS status) and even on the success path, the stream is abandoned. The underlying gRPC connection is held until `ctx` cancellation rather than released immediately, leaking one stream per call.

## Change

`tools/fxconfig/internal/client/orderer.go:82`, add `defer abc.CloseSend()` immediately after the stream is successfully opened. `CloseSend` only signals end-of-send to the server; it doesn't tear down the connection or affect the in-flight `Recv`, so all four exit paths now release the stream cleanly.

## Test plan

- [x] `go build ./tools/fxconfig/...`, clean
- [x] `go vet ./tools/fxconfig/...`, clean
- [x] No behaviour change beyond the cleanup; `Recv` still runs after `Send` and returns the same status before `defer` fires