### PR TITLE
fix(fxconfig): make dropped notifications observable with logging and counter

### DIFF
--- a/tools/fxconfig/internal/client/notifications.go
+++ b/tools/fxconfig/internal/client/notifications.go
@@ -37,6 +37,12 @@ type NotificationClient struct {
 	// streamErr holds the error that caused the stream to terminate.
 	// Atomically stored; checked by Subscribe() before sending requests.
 	streamErr atomic.Pointer[error]
+
+	// droppedNotifications counts status events that the dispatcher could not
+	// deliver because the subscriber's channel buffer was full or the receiver
+	// had already given up. Exposed via DroppedNotifications for diagnostics
+	// and tests.
+	droppedNotifications atomic.Uint64
 }
 
 // NewNotificationClient creates a notification client with the provided configuration.
@@ -236,11 +242,6 @@ func (n *NotificationClient) listen(ctx context.Context) error {
 
 	// spawn notification dispatcher
 	g.Go(func() error {
-		type notificationCall struct {
-			receiverQueue chan int
-			status        int
-		}
-
 		var resp *committerpb.NotificationResponse
 		for {
 			select {
@@ -249,33 +250,7 @@ func (n *NotificationClient) listen(ctx context.Context) error {
 			case resp = <-n.responseQueue:
 			}
 
-			res := parseResponse(resp)
-
-			// Collect subscribers under lock, then release before spawning goroutines.
-			// This minimizes lock hold time — only map lookups and deletes happen
-			// under the lock. Goroutine scheduling happens entirely outside.
-			var notifications []notificationCall
-
-			n.subscribersMu.Lock()
-			for txID, v := range res {
-				receivers, ok := n.subscribers[txID]
-				if !ok {
-					continue
-				}
-				delete(n.subscribers, txID)
-				for _, q := range receivers {
-					notifications = append(notifications, notificationCall{receiverQueue: q, status: v})
-				}
-			}
-			n.subscribersMu.Unlock()
-
-			for _, c := range notifications {
-				select {
-				case c.receiverQueue <- c.status:
-				default:
-					// message dropped
-				}
-			}
+			n.dispatchNotifications(n.collectNotifications(parseResponse(resp)))
 		}
 	})
 
@@ -292,6 +267,67 @@ func (n *NotificationClient) listen(ctx context.Context) error {
 	n.subscribersMu.Unlock()
 
 	return err
+}
+
+// notificationCall is a single status event ready for delivery to a subscriber.
+type notificationCall struct {
+	txID          string
+	receiverQueue chan int
+	status        int
+}
+
+// collectNotifications snapshots and removes all subscribers whose txIDs
+// appear in res, returning one notificationCall per subscriber. Holding the
+// subscribers lock only for the duration of the lookup/delete keeps the
+// dispatcher hot path short.
+func (n *NotificationClient) collectNotifications(res map[string]int) []notificationCall {
+	var notifications []notificationCall
+
+	n.subscribersMu.Lock()
+	defer n.subscribersMu.Unlock()
+
+	for txID, v := range res {
+		receivers, ok := n.subscribers[txID]
+		if !ok {
+			continue
+		}
+		delete(n.subscribers, txID)
+		for _, q := range receivers {
+			notifications = append(notifications, notificationCall{
+				txID:          txID,
+				receiverQueue: q,
+				status:        v,
+			})
+		}
+	}
+
+	return notifications
+}
+
+// dispatchNotifications sends each pending status to its subscriber. The send
+// is non-blocking so a single slow subscriber cannot stall the dispatcher
+// goroutine, but every dropped event is logged and counted — the txID has
+// already been removed from the subscribers map, so a drop is unrecoverable
+// and must be observable.
+func (n *NotificationClient) dispatchNotifications(notifications []notificationCall) {
+	for _, c := range notifications {
+		select {
+		case c.receiverQueue <- c.status:
+		default:
+			n.droppedNotifications.Add(1)
+			logger.Warnf(
+				"notification dropped (unrecoverable): txID=%s status=%d (subscriber buffer full or receiver gone)",
+				c.txID, c.status,
+			)
+		}
+	}
+}
+
+// DroppedNotifications returns the cumulative count of status events that the
+// dispatcher could not deliver to a subscriber (buffer full or receiver
+// already gone). Useful for end-of-run diagnostics and tests.
+func (n *NotificationClient) DroppedNotifications() uint64 {
+	return n.droppedNotifications.Load()
 }
 
 // parseResponse extracts transaction statuses from a notification response,

--- a/tools/fxconfig/internal/client/notifications_test.go
+++ b/tools/fxconfig/internal/client/notifications_test.go
@@ -274,6 +274,93 @@ func TestNotificationClient_Subscribe_Timeout(t *testing.T) {
 	require.ErrorContains(t, err, "deadline exceeded")
 }
 
+// dispatchNotifications / collectNotifications tests
+
+func TestDispatchNotifications_DeliversToSubscriber(t *testing.T) {
+	t.Parallel()
+
+	nc := newTestNotificationClient(time.Second)
+	ch := make(chan int, 1)
+
+	nc.dispatchNotifications([]notificationCall{
+		{txID: "tx1", receiverQueue: ch, status: 7},
+	})
+
+	require.Equal(t, 7, <-ch)
+	require.Equal(t, uint64(0), nc.DroppedNotifications())
+}
+
+func TestDispatchNotifications_DropsWhenBufferFull(t *testing.T) {
+	t.Parallel()
+
+	nc := newTestNotificationClient(time.Second)
+	ch := make(chan int, 1)
+	ch <- 1 // pre-fill the single-slot buffer
+
+	nc.dispatchNotifications([]notificationCall{
+		{txID: "tx1", receiverQueue: ch, status: 2},
+	})
+
+	require.Equal(t, uint64(1), nc.DroppedNotifications())
+	// Original value is preserved; the drop did not corrupt the buffer.
+	require.Equal(t, 1, <-ch)
+}
+
+func TestDispatchNotifications_CountsEachDropIndependently(t *testing.T) {
+	t.Parallel()
+
+	nc := newTestNotificationClient(time.Second)
+	full1 := make(chan int, 1)
+	full1 <- 0
+	full2 := make(chan int, 1)
+	full2 <- 0
+	open := make(chan int, 1)
+
+	nc.dispatchNotifications([]notificationCall{
+		{txID: "tx1", receiverQueue: full1, status: 1},
+		{txID: "tx2", receiverQueue: full2, status: 2},
+		{txID: "tx3", receiverQueue: open, status: 3},
+	})
+
+	require.Equal(t, uint64(2), nc.DroppedNotifications())
+	require.Equal(t, 3, <-open)
+}
+
+func TestCollectNotifications_RemovesSubscribersAndCarriesTxID(t *testing.T) {
+	t.Parallel()
+
+	nc := newTestNotificationClient(time.Second)
+	chA := make(chan int, 1)
+	chB := make(chan int, 1)
+	nc.subscribers["tx1"] = []chan int{chA}
+	nc.subscribers["tx2"] = []chan int{chB}
+
+	got := nc.collectNotifications(map[string]int{"tx1": 11, "tx2": 22})
+
+	require.Len(t, got, 2)
+	// Subscribers must be removed so a future drop is correctly observable.
+	require.Empty(t, nc.subscribers)
+
+	byTxID := map[string]notificationCall{}
+	for _, c := range got {
+		byTxID[c.txID] = c
+	}
+	require.Equal(t, 11, byTxID["tx1"].status)
+	require.Equal(t, chA, byTxID["tx1"].receiverQueue)
+	require.Equal(t, 22, byTxID["tx2"].status)
+	require.Equal(t, chB, byTxID["tx2"].receiverQueue)
+}
+
+func TestCollectNotifications_IgnoresUnknownTxIDs(t *testing.T) {
+	t.Parallel()
+
+	nc := newTestNotificationClient(time.Second)
+	got := nc.collectNotifications(map[string]int{"unknown": 1})
+
+	require.Empty(t, got)
+	require.Equal(t, uint64(0), nc.DroppedNotifications())
+}
+
 // Close tests
 
 func TestNotificationClient_Close_CallsCloseFunc(t *testing.T) {


### PR DESCRIPTION
#### Type of change

- Bug fix #217
- Improvement (improvement to code, performance, etc)
- Test update

#### Description

The notification dispatcher in `NotificationClient.listen` (`tools/fxconfig/internal/client/notifications.go:223–228`) used a non-blocking send with a bare `// message dropped` comment in the `default` branch. Any status event that could not be delivered to a subscriber's channel was silently discarded - no log line, no counter, no error returned to the caller.

This is particularly harmful because the txID is removed from the subscribers map *before* the send is attempted, making every drop unrecoverable. From the caller's perspective the drop is indistinguishable from a genuine committer timeout, corrupting any retry or SLA decision built on top.

**Changes:**
- Added a `droppedNotifications atomic.Uint64` field to `NotificationClient` and an exported `DroppedNotifications() uint64` accessor for diagnostics and tests.
- Each drop now emits a `WARN`-level log via the existing `flogging` `"client"` logger, including the `txID` and `status`.
- Extracted the dispatch loop from `listen` into two focused methods `collectNotifications` and `dispatchNotifications`  and promoted `notificationCall` to package scope with a `txID` field, making the drop path directly unit-testable.
- Replaced the legacy `fmt.Printf` listener-error line with `logger.Errorf` (the commented-out `logger.Errorf` directly beneath it already showed the intent).