### PR TITLE
fix(cryptogen): write error output to stderr and use standard exit code

### DIFF
--- a/tools/cryptogen/main.go
+++ b/tools/cryptogen/main.go
@@ -59,8 +59,8 @@ func main() {
 	}
 
 	if err != nil {
-		fmt.Printf("error executing command %s\n%s", cmd, err)
-		os.Exit(-1)
+		fmt.Fprintf(os.Stderr, "error executing command %s\n%s\n", cmd, err)
+		os.Exit(1)
 	}
 }
 

--- a/tools/cryptogen/main_test.go
+++ b/tools/cryptogen/main_test.go
@@ -7,12 +7,55 @@ SPDX-License-Identifier: Apache-2.0
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+// TestExecutionErrorRoutedToStderr exercises the top-level error handler in
+// main() by re-invoking the test binary as a subprocess with an unparseable
+// config file. It guards two POSIX-conformance properties:
+//  1. Errors are written to stderr (not stdout) so callers piping stdout do
+//     not silently capture error text alongside any future structured output.
+//  2. The exit code is exactly 1 (not -1, which wraps to 255 on POSIX and is
+//     conventionally reserved for shell signals / out-of-range statuses).
+func TestExecutionErrorRoutedToStderr(t *testing.T) {
+	if os.Getenv("CRYPTOGEN_RUN_MAIN") == "1" {
+		argv := strings.Fields(os.Getenv("CRYPTOGEN_ARGS"))
+		os.Args = append([]string{"cryptogen"}, argv...)
+		main()
+		return
+	}
+
+	tmpDir := t.TempDir()
+	badCfg := filepath.Join(tmpDir, "bad.yaml")
+	require.NoError(t, os.WriteFile(badCfg, []byte("{unterminated: "), 0o600))
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestExecutionErrorRoutedToStderr$")
+	cmd.Env = append(os.Environ(),
+		"CRYPTOGEN_RUN_MAIN=1",
+		"CRYPTOGEN_ARGS=generate --config "+badCfg,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr, "expected non-zero exit")
+	require.Equal(t, 1, exitErr.ExitCode(), "exit code must be 1, not -1/255")
+	require.NotContains(t, stdout.String(), "error executing command",
+		"error text must not appear on stdout")
+	require.Contains(t, stderr.String(), "error executing command",
+		"error text must appear on stderr")
+}
 
 func TestGetVersionInfo(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
#### Type of change

- Bug fix
- Test update

#### Description

`cryptogen` wrote command errors with `fmt.Printf` (stdout) and exited with `os.Exit(-1)`, which wraps to `255` on POSIX shells. Errors should go to stderr and use a conventional non-zero exit (e.g. `1`) so pipelines and scripts behave predictably—similar to other tools in this repo.

**Changes:**

- `tools/cryptogen/main.go` -> emit errors via `fmt.Fprintf(os.Stderr, ...)` and `os.Exit(1)`.
- `tools/cryptogen/main_test.go` -> TestExecutionErrorRoutedToStderr` subprocess test: malformed config - stderr contains the error line, stdout does not; exit status `1`

#### Additional details (Optional)

**Suggested checks:**  
`go test ./tools/cryptogen/`  
`go vet ./tools/cryptogen/`

