### PR TITLE
fix(fxconfig/validation): treat ".." only as a path component, not as…

### DIFF
--- a/tools/fxconfig/internal/validation/validator.go
+++ b/tools/fxconfig/internal/validation/validator.go
@@ -16,6 +16,20 @@ import (
 	"github.com/hyperledger/fabric-x-common/common/policydsl"
 )
 
+// hasTraversalComponent reports whether the cleaned path attempts to escape
+// its base via a ".." component. After filepath.Clean, the only way ".." can
+// remain is as a leading component (either the entire path or a "../" prefix);
+// any internal "..foo" or "foo..bar" segments are legitimate filename text
+// and must not be treated as traversal. This is intentionally stricter than
+// strings.Contains(clean, ".."), which produced false positives for any
+// filename whose name contained two consecutive dots.
+func hasTraversalComponent(clean string) bool {
+	if clean == ".." {
+		return true
+	}
+	return strings.HasPrefix(clean, ".."+string(filepath.Separator))
+}
+
 // NewValidationContext creates a validation context with OS-based validators.
 // Returns a Context configured with PolicyDSLChecker, OSFileChecker, and OSDirectoryChecker.
 func NewValidationContext() Context {
@@ -50,7 +64,7 @@ func (OSFileChecker) Exists(path string) error {
 	}
 
 	clean := filepath.Clean(path)
-	if strings.Contains(clean, "..") {
+	if hasTraversalComponent(clean) {
 		return errors.New("path traversal not allowed")
 	}
 
@@ -79,7 +93,7 @@ func (OSDirectoryChecker) Exists(path string) error {
 	}
 
 	clean := filepath.Clean(path)
-	if strings.Contains(clean, "..") {
+	if hasTraversalComponent(clean) {
 		return errors.New("path traversal not allowed")
 	}
 

--- a/tools/fxconfig/internal/validation/validator_test.go
+++ b/tools/fxconfig/internal/validation/validator_test.go
@@ -54,6 +54,16 @@ func TestOSFileChecker_Exists(t *testing.T) {
 	tmpFile := filepath.Join(tmpDir, "key.pem")
 	require.NoError(t, os.WriteFile(tmpFile, []byte("data"), 0o600))
 
+	// Files whose names legitimately contain ".." used to be rejected by
+	// strings.Contains(clean, ".."). These cases guard the fix that scopes
+	// the traversal check to ".." as a path component, not a substring.
+	dottyFile := filepath.Join(tmpDir, "myproject..backup")
+	require.NoError(t, os.WriteFile(dottyFile, []byte("data"), 0o600))
+	configDottyFile := filepath.Join(tmpDir, "config..yaml")
+	require.NoError(t, os.WriteFile(configDottyFile, []byte("data"), 0o600))
+	leadingDotsFile := filepath.Join(tmpDir, "..hidden")
+	require.NoError(t, os.WriteFile(leadingDotsFile, []byte("data"), 0o600))
+
 	tests := []struct {
 		name    string
 		path    string
@@ -64,6 +74,11 @@ func TestOSFileChecker_Exists(t *testing.T) {
 		{"non-existent", filepath.Join(tmpDir, "missing.pem"), true},
 		{"directory given", tmpDir, true},
 		{"path traversal", "../../etc/passwd", true},
+		{"single dotdot", "..", true},
+		{"filename containing dotdot is accepted", dottyFile, false},
+		{"config name with dotdot is accepted", configDottyFile, false},
+		{"filename with leading dotdot is accepted", leadingDotsFile, false},
+		{"internal dotdot collapses to valid path", filepath.Join(tmpDir, "sub", "..", "key.pem"), false},
 	}
 
 	for _, tt := range tests {
@@ -88,6 +103,14 @@ func TestOSDirectoryChecker_Exists(t *testing.T) {
 	tmpFile := filepath.Join(tmpDir, "file.txt")
 	require.NoError(t, os.WriteFile(tmpFile, []byte("data"), 0o600))
 
+	// Directories whose names legitimately contain ".." used to be rejected.
+	// These cases guard the fix that scopes the traversal check to ".." as
+	// a path component, not a substring.
+	dottyDir := filepath.Join(tmpDir, "release..2026-04")
+	require.NoError(t, os.MkdirAll(dottyDir, 0o755))
+	leadingDotsDir := filepath.Join(tmpDir, "..staging")
+	require.NoError(t, os.MkdirAll(leadingDotsDir, 0o755))
+
 	tests := []struct {
 		name    string
 		path    string
@@ -98,6 +121,10 @@ func TestOSDirectoryChecker_Exists(t *testing.T) {
 		{"non-existent", filepath.Join(tmpDir, "missing"), true},
 		{"file given", tmpFile, true},
 		{"path traversal", "../../etc", true},
+		{"single dotdot", "..", true},
+		{"directory name containing dotdot is accepted", dottyDir, false},
+		{"directory name with leading dotdot is accepted", leadingDotsDir, false},
+		{"internal dotdot collapses to valid directory", filepath.Join(tmpDir, "sub", ".."), false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
#### Type of change

- Bug fix
- Test update

#### Description

`OSFileChecker` and `OSDirectoryChecker` rejected any cleaned path containing the substring `".."`, which blocked valid paths whose **file or directory names** include two dots (for example names like `foo..backup` or `config..yaml`), not actual traversal

**Change:** Replace the substring check with a rule that only treats leading `..` segments (whole path `".."` or prefix `".." + filepath.Separator`) as traversal, consistent with paths left by `filepath.Clean`

**Tests:** Extended `tools/fxconfig/internal/validation/validator_test.go` with cases for benign `..`-in-name paths, regressions (`..`, `../…`), and internal `..` segments that `Clean` collapses

#### Additional details (Optional)

**Suggested checks:**  
`go test -race ./tools/fxconfig/internal/validation/...`  
(or `go test -race ./tools/fxconfig/...` including integration tests if you prefer a full sweep)
