### PR TITLE
feat(fxconfig): add basic snapshot validation helper and tests

### DIFF
--- a/tools/fxconfig/internal/validation/snapshot_validation.go
+++ b/tools/fxconfig/internal/validation/snapshot_validation.go
@@ -1,0 +1,50 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package validation
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Namespace represents key-value pairs in a namespace.
+type Namespace map[string]string
+
+// Snapshot represents a simplified snapshot structure.
+type Snapshot struct {
+	Channel    string
+	Namespaces map[string]Namespace
+}
+
+// ValidateSnapshot performs minimal structural validation.
+func ValidateSnapshot(s Snapshot) error {
+	if s.Channel == "" {
+		return errors.New("channel is empty")
+	}
+
+	if len(s.Namespaces) == 0 {
+		return errors.New("no namespaces found")
+	}
+
+	for ns, kv := range s.Namespaces {
+		if ns == "" {
+			return errors.New("empty namespace name")
+		}
+
+		if len(kv) == 0 {
+			return fmt.Errorf("namespace %s has no keys", ns)
+		}
+
+		for k := range kv {
+			if k == "" {
+				return fmt.Errorf("empty key in namespace %s", ns)
+			}
+		}
+	}
+
+	return nil
+}

--- a/tools/fxconfig/internal/validation/snapshot_validation_test.go
+++ b/tools/fxconfig/internal/validation/snapshot_validation_test.go
@@ -1,0 +1,100 @@
+// Copyright IBM Corp. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import "testing"
+
+func TestValidateSnapshot_Success(t *testing.T) {
+	t.Parallel()
+
+	s := Snapshot{
+		Channel: "mychannel",
+		Namespaces: map[string]Namespace{
+			"asset": {
+				"a1": "v1",
+				"a2": "v2",
+			},
+		},
+	}
+
+	if err := ValidateSnapshot(s); err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+}
+
+func TestValidateSnapshot_EmptyChannel(t *testing.T) {
+	t.Parallel()
+
+	s := Snapshot{
+		Channel: "",
+		Namespaces: map[string]Namespace{
+			"asset": {"a1": "v1"},
+		},
+	}
+
+	if err := ValidateSnapshot(s); err == nil {
+		t.Fatal("expected error for empty channel")
+	}
+}
+
+func TestValidateSnapshot_NoNamespaces(t *testing.T) {
+	t.Parallel()
+
+	s := Snapshot{
+		Channel:    "mychannel",
+		Namespaces: map[string]Namespace{},
+	}
+
+	if err := ValidateSnapshot(s); err == nil {
+		t.Fatal("expected error for no namespaces")
+	}
+}
+
+func TestValidateSnapshot_EmptyNamespace(t *testing.T) {
+	t.Parallel()
+
+	s := Snapshot{
+		Channel: "mychannel",
+		Namespaces: map[string]Namespace{
+			"asset": {},
+		},
+	}
+
+	if err := ValidateSnapshot(s); err == nil {
+		t.Fatal("expected error for empty namespace")
+	}
+}
+
+func TestValidateSnapshot_EmptyNamespaceName(t *testing.T) {
+	t.Parallel()
+
+	s := Snapshot{
+		Channel: "mychannel",
+		Namespaces: map[string]Namespace{
+			"": {"a1": "v1"},
+		},
+	}
+
+	if err := ValidateSnapshot(s); err == nil {
+		t.Fatal("expected error for empty namespace name")
+	}
+}
+
+func TestValidateSnapshot_EmptyKey(t *testing.T) {
+	t.Parallel()
+
+	s := Snapshot{
+		Channel: "mychannel",
+		Namespaces: map[string]Namespace{
+			"asset": {
+				"": "v1",
+			},
+		},
+	}
+
+	if err := ValidateSnapshot(s); err == nil {
+		t.Fatal("expected error for empty key")
+	}
+}


### PR DESCRIPTION
#### Type of change

* New feature
* Test update

#### Description

This PR introduces a minimal validation helper for snapshot-like data structures to ensure basic structural correctness before processing.

The validation checks:

* non-empty channel
* presence of namespaces
* non-empty namespace names
* non-empty key sets
* valid (non-empty) keys

The goal is to provide a lightweight guard against malformed snapshot input, helping prevent issues during transformation or export stages.

Unit tests are included to cover both valid and invalid scenarios.

#### Additional details (Optional)

* Implemented as a standalone utility under `internal/validation` to keep the scope minimal
* No changes to existing logic or public APIs
* Tests include success and edge-case validation (empty channel, namespaces, keys, etc.)

Validation:

* `go test ./tools/fxconfig/... -count=1` passed
* `make lint` passed

#### Related issues

Closes #227 
