### PR TITLE
fix(cryptogen): improve error handling and add config parsing test

### DIFF
--- a/tools/cryptogen/main.go
+++ b/tools/cryptogen/main.go
@@ -51,16 +51,20 @@ func main() {
 	case ext.FullCommand():
 		err = extend()
 	case showtemplate.FullCommand():
-		_, _ = fmt.Print(sampleconfig.DefaultCryptoConfig)
+		if _, err = fmt.Print(sampleconfig.DefaultCryptoConfig); err != nil {
+			err = fmt.Errorf("failed to write template: %w", err)
+		}
 	case versionCmd.FullCommand():
-		_, _ = fmt.Println(getVersionInfo())
+		if _, err = fmt.Println(getVersionInfo()); err != nil {
+			err = fmt.Errorf("failed to write version info: %w", err)
+		}
 	default:
 		panic("programming error")
 	}
 
 	if err != nil {
-		fmt.Printf("error executing command %s\n%s", cmd, err)
-		os.Exit(-1)
+		_, _ = fmt.Fprintf(os.Stderr, "error executing command %s: %v\n", cmd, err)
+		os.Exit(1)
 	}
 }
 
@@ -98,7 +102,11 @@ func getConfig() (*cryptogen.Config, error) {
 	default:
 		configData = sampleconfig.DefaultCryptoConfig
 	}
-	return cryptogen.ParseConfig(configData)
+	cfg, err := cryptogen.ParseConfig(configData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse config: %w", err)
+	}
+	return cfg, nil
 }
 
 func getVersionInfo() string {

--- a/tools/cryptogen/main_test.go
+++ b/tools/cryptogen/main_test.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"testing"
 
@@ -37,4 +38,38 @@ func TestGetVersionInfo(t *testing.T) {
 		fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	)
 	require.Equal(t, expected, getVersionInfo())
+}
+
+func TestGetConfig_InvalidFile(t *testing.T) {
+	t.Parallel()
+
+	// Create temp invalid config file
+	f, err := os.CreateTemp(t.TempDir(), "invalid-config-*.yaml")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+
+	// Write invalid content
+	_, _ = f.WriteString("invalid: [unclosed")
+	if closeErr := f.Close(); closeErr != nil {
+		t.Fatalf("failed to close temp file: %v", closeErr)
+	}
+
+	// Save original value and restore after test
+	originalGenConfigFile := genConfigFile
+	defer func() { genConfigFile = originalGenConfigFile }()
+
+	// Simulate CLI flag
+	fHandle, err := os.Open(f.Name())
+	if err != nil {
+		t.Fatalf("failed to open temp file: %v", err)
+	}
+	defer func() {
+		_ = fHandle.Close()
+	}()
+	genConfigFile = &fHandle
+
+	_, err = getConfig()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse config")
 }


### PR DESCRIPTION
#### Type of change

* Improvement
* Test update

#### Description

This PR improves error handling in the cryptogen CLI and adds test coverage for configuration parsing failures.

Changes include:

* removing ignored errors from fmt.Print/Println calls
* improving error propagation with context in configuration parsing
* standardizing error output to stderr with proper exit codes
* adding a test to validate behavior on invalid configuration input

These changes improve reliability and make failures easier to diagnose without modifying core functionality.
