### PR TITLE
fix(fxconfig): reject expired client TLS certificates during validation

### DIFF
--- a/tools/fxconfig/internal/config/validate.go
+++ b/tools/fxconfig/internal/config/validate.go
@@ -8,6 +8,7 @@ package config
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"net"
@@ -92,9 +93,17 @@ func (c *TLSConfig) Validate(vctx validation.Context) error {
 		return fmt.Errorf("invalid clientKeyPath: %w", err)
 	}
 
-	// try to load key pair
-	if _, err := tls.LoadX509KeyPair(c.ClientCertPath, c.ClientKeyPath); err != nil {
+	// try to load key pair and check certificate validity
+	cert, err := tls.LoadX509KeyPair(c.ClientCertPath, c.ClientKeyPath)
+	if err != nil {
 		return fmt.Errorf("invalid cert/key pair: %w", err)
+	}
+
+	if len(cert.Certificate) > 0 {
+		leaf, parseErr := x509.ParseCertificate(cert.Certificate[0])
+		if parseErr == nil && time.Now().After(leaf.NotAfter) {
+			return fmt.Errorf("client certificate expired at %s", leaf.NotAfter.UTC().Format(time.RFC3339))
+		}
 	}
 
 	return nil

--- a/tools/fxconfig/internal/config/validate_test.go
+++ b/tools/fxconfig/internal/config/validate_test.go
@@ -7,9 +7,20 @@ SPDX-License-Identifier: Apache-2.0
 package config
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/validation"
 )
 
 // TestErrorIfEmpty tests the errorIfEmpty helper function.
@@ -75,4 +86,91 @@ func TestErrorIfEmpty(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestTLSConfigValidate_ExpiredCertificate verifies that validation rejects an expired client certificate.
+func TestTLSConfigValidate_ExpiredCertificate(t *testing.T) {
+	t.Parallel()
+
+	keyPEM, certPEM, caCertPEM := generateSelfSignedCert(t, time.Now().Add(-48*time.Hour), time.Now().Add(-1*time.Hour))
+
+	dir := t.TempDir()
+	keyPath := writeTempFile(t, dir, "client.key", keyPEM)
+	certPath := writeTempFile(t, dir, "client.crt", certPEM)
+	caPath := writeTempFile(t, dir, "ca.crt", caCertPEM)
+
+	enabled := true
+	cfg := &TLSConfig{
+		Enabled:        &enabled,
+		ClientKeyPath:  keyPath,
+		ClientCertPath: certPath,
+		RootCertPaths:  []string{caPath},
+	}
+
+	err := cfg.Validate(validation.NewValidationContext())
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expired")
+}
+
+// TestTLSConfigValidate_ValidCertificate verifies that a currently valid certificate passes validation.
+func TestTLSConfigValidate_ValidCertificate(t *testing.T) {
+	t.Parallel()
+
+	keyPEM, certPEM, caCertPEM := generateSelfSignedCert(t, time.Now().Add(-1*time.Hour), time.Now().Add(24*time.Hour))
+
+	dir := t.TempDir()
+	keyPath := writeTempFile(t, dir, "client.key", keyPEM)
+	certPath := writeTempFile(t, dir, "client.crt", certPEM)
+	caPath := writeTempFile(t, dir, "ca.crt", caCertPEM)
+
+	enabled := true
+	cfg := &TLSConfig{
+		Enabled:        &enabled,
+		ClientKeyPath:  keyPath,
+		ClientCertPath: certPath,
+		RootCertPaths:  []string{caPath},
+	}
+
+	err := cfg.Validate(validation.NewValidationContext())
+
+	require.NoError(t, err)
+}
+
+// generateSelfSignedCert creates a self-signed ECDSA certificate with the given validity window.
+// Returns the key, certificate, and CA certificate as PEM-encoded bytes.
+func generateSelfSignedCert(t *testing.T, notBefore, notAfter time.Time) (keyPEM, certPEM, caCertPEM []byte) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test"},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	keyBytes, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	caCertPEM = certPEM
+
+	return keyPEM, certPEM, caCertPEM
+}
+
+func writeTempFile(t *testing.T, dir, name string, content []byte) string {
+	t.Helper()
+	path := dir + "/" + name
+	require.NoError(t, os.WriteFile(path, content, 0o600))
+	return path
 }


### PR DESCRIPTION
#### Description

`tls.LoadX509KeyPair` validates that a cert/key pair is parseable and
consistent but does not check certificate validity dates. An expired
client certificate silently passes `TLSConfig.Validate` and only fails
later with a cryptic TLS handshake error, making the root cause hard to
diagnose.

This PR parses the leaf certificate from the loaded key pair and returns
a descriptive error if `time.Now()` is past `NotAfter`:

```
client certificate expired at 2026-01-01T00:00:00Z
```

The check is a no-op when the certificate block is absent (non-mTLS TLS
configurations are unaffected).

#### Additional details (Optional)

Tests added:
- `TestTLSConfigValidate_ExpiredCertificate` — generates a self-signed
  cert with `NotAfter` in the past; asserts validation returns an error
  containing `"expired"`
- `TestTLSConfigValidate_ValidCertificate` — generates a self-signed
  cert with `NotAfter` 24 h in the future; asserts validation passes

All unit tests pass: `go test ./fxconfig/internal/...`
Lint clean: `golangci-lint run --new-from-rev=origin/main ./fxconfig/...`

Signed-off-by: pradhyum6144 <pradhyum314@gmail.com>