### PR TITLE
Refactor error handling for `os.Getwd()` in main.go files across endo…

### DIFF
--- a/samples/tokens/endorser/main.go
+++ b/samples/tokens/endorser/main.go
@@ -25,7 +25,10 @@ import (
 
 func main() {
 	// Flags
-	cwd, _ := os.Getwd()
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
 	pth := flag.String("conf", cwd, "the directory that contains the core.yaml configuration file")
 	port := flag.String("port", "9000", "the API port for the application")
 	flag.Parse()

--- a/samples/tokens/issuer/main.go
+++ b/samples/tokens/issuer/main.go
@@ -29,7 +29,10 @@ import (
 
 func main() {
 	// Flags
-	cwd, _ := os.Getwd()
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
 	pth := flag.String("conf", cwd, "the directory that contains the core.yaml configuration file")
 	port := flag.String("port", "9000", "the API port for the application")
 	flag.Parse()

--- a/samples/tokens/owner/main.go
+++ b/samples/tokens/owner/main.go
@@ -28,7 +28,10 @@ import (
 )
 
 func main() {
-	cwd, _ := os.Getwd()
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
 	pth := flag.String("conf", cwd, "the directory that contains the core.yaml configuration file")
 	port := flag.String("port", "9000", "the API port for the application")
 	flag.Parse()


### PR DESCRIPTION
 Fix error handling for os.Getwd() in token sample binaries
                                                                                                                   
  Summary                                                                                                        
                                                                                                                   
  - Replace silent error discards (cwd, _ := os.Getwd()) with proper error handling across all three token sample  
  entry points
  - samples/tokens/endorser/main.go, samples/tokens/issuer/main.go, and samples/tokens/owner/main.go now call      
  log.Fatal(err) if os.Getwd() fails, ensuring failures are surfaced immediately rather than silently propagating a
   zero-value path
                                                                                                                   
  Motivation                                                                                                     

  Ignoring errors from os.Getwd() could cause the samples to start with an empty working directory path, leading to
   confusing downstream failures when loading configuration files. Logging and exiting on error makes the failure
  mode explicit and easier to diagnose.                                                                            
                                                                                                                 
  Test plan

  - Run each sample binary and verify it starts correctly under normal conditions                                  
  - Verify that a failure in os.Getwd() results in a fatal log message rather than silent misbehavior
#243 