### PR TITLE
Refactor context initialization in main.go files to use context.Background() instead of context.TODO() 

### DIFF
--- a/samples/tokens/endorser/main.go
+++ b/samples/tokens/endorser/main.go
@@ -50,7 +50,7 @@ func main() {
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
 	<-stop
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	s.Shutdown(ctx)
 	fsc.Stop()

--- a/samples/tokens/issuer/main.go
+++ b/samples/tokens/issuer/main.go
@@ -59,7 +59,7 @@ func main() {
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
 	<-stop
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	s.Shutdown(ctx)
 	fsc.Stop()

--- a/samples/tokens/owner/main.go
+++ b/samples/tokens/owner/main.go
@@ -59,7 +59,7 @@ func main() {
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
 	<-stop
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	s.Shutdown(ctx)
 	fsc.Stop()


### PR DESCRIPTION
Summary                                                                                                                                            
                                                                                                                                                     
  - Replaced context.TODO() with context.Background() in samples/tokens/issuer/main.go, samples/tokens/owner/main.go, and                            
  samples/tokens/endorser/main.go
  - context.TODO() is a placeholder for undecided contexts; at the top level of main(), context.Background() is the correct idiomatic choice as it   
  explicitly signals an intentional root context                                                                                                     
  
  Related Issue                                                                                                                                      
                                                                                                                                                   
  Closes #245

  Type of Change

  - Improvement (code clarity/correctness)