### PR TITLE
fix(transaction): validate endorsements count on merge

### DIFF
--- a/tools/fxconfig/internal/transaction/merge.go
+++ b/tools/fxconfig/internal/transaction/merge.go
@@ -61,6 +61,15 @@ func validateTransactionsForMerge(txs []*applicationpb.Tx) error {
 			return fmt.Errorf("transaction %d: namespace count mismatch", i)
 		}
 
+		if len(tx.GetEndorsements()) != baseNsCount {
+			return fmt.Errorf(
+				"transaction %d: endorsements count (%d) does not match namespaces count (%d)",
+				i,
+				len(tx.GetEndorsements()),
+				baseNsCount,
+			)
+		}
+
 		for nsIdx := range baseTx.GetNamespaces() {
 			if !proto.Equal(baseTx.GetNamespaces()[nsIdx], txs[i].GetNamespaces()[nsIdx]) {
 				return fmt.Errorf("transaction %d: namespace %d content mismatch", i, nsIdx)

--- a/tools/fxconfig/internal/transaction/merge_test.go
+++ b/tools/fxconfig/internal/transaction/merge_test.go
@@ -109,6 +109,50 @@ func TestMerge_ErrorCases(t *testing.T) {
 		require.Contains(t, err.Error(), "requires at least one endorsement")
 	})
 
+	t.Run("endorsements count mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		tx1 := &applicationpb.Tx{
+			Namespaces: []*applicationpb.TxNamespace{
+				{NsId: "ns1", NsVersion: 1},
+			},
+			Endorsements: []*applicationpb.Endorsements{
+				{
+					EndorsementsWithIdentity: []*applicationpb.EndorsementWithIdentity{
+						{Endorsement: []byte("sig-a1"), Identity: &msppb.Identity{MspId: "Org1MSP"}},
+					},
+				},
+				{
+					EndorsementsWithIdentity: []*applicationpb.EndorsementWithIdentity{
+						{Endorsement: []byte("sig-a2"), Identity: &msppb.Identity{MspId: "Org2MSP"}},
+					},
+				},
+			},
+		}
+		tx2 := &applicationpb.Tx{
+			Namespaces: []*applicationpb.TxNamespace{
+				{NsId: "ns1", NsVersion: 1},
+			},
+			Endorsements: []*applicationpb.Endorsements{
+				{
+					EndorsementsWithIdentity: []*applicationpb.EndorsementWithIdentity{
+						{Endorsement: []byte("sig-b1"), Identity: &msppb.Identity{MspId: "Org3MSP"}},
+					},
+				},
+				{
+					EndorsementsWithIdentity: []*applicationpb.EndorsementWithIdentity{
+						{Endorsement: []byte("sig-b2"), Identity: &msppb.Identity{MspId: "Org4MSP"}},
+					},
+				},
+			},
+		}
+
+		result, err := Merge([]*applicationpb.Tx{tx1, tx2})
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Contains(t, err.Error(), "endorsements count")
+	})
+
 	t.Run("conflicting namespace writes", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

This change prevents `Merge` from panicking when a transaction carries more
endorsement entries than namespace entries.

Previously, `mergeEndorsements` allocated its internal slices using
`len(txs[0].GetNamespaces())`, but then indexed them using positions from
`tx.GetEndorsements()`. When `len(Endorsements) > len(Namespaces)` for any
transaction, this led to an `index out of range` panic.

To fix this, `validateTransactionsForMerge` now checks that, for every
transaction, the endorsements count matches the base namespace count. If not,
`Merge` returns a descriptive error instead of panicking.

A test case was added to `TestMerge_ErrorCases` to cover the endorsements
count mismatch scenario.

#### Additional details (Optional)

The new validation leverages the existing `baseNsCount` computed from the
first transaction, so the check is performed consistently with the existing
namespace-count validation. The error message includes the transaction index
and both counts to aid debugging.

Tests:
- `go test ./tools/fxconfig/internal/transaction -run TestMerge_ErrorCases -v`

#### Related issues

- https://github.com/hyperledger/fabric-x/issues/238