### PR TITLE
fix(fxconfig/transaction): surface policy key parse errors

### DIFF
--- a/tools/fxconfig/internal/transaction/policy.go
+++ b/tools/fxconfig/internal/transaction/policy.go
@@ -64,6 +64,8 @@ func CreateThresholdPolicy(path string) (*applicationpb.NamespacePolicy, error) 
 // getPubKeyFromPemData extracts an ECDSA public key from PEM-encoded content.
 // It searches through multiple PEM blocks and returns the first valid ECDSA public key found.
 func getPubKeyFromPemData(pemContent []byte) ([]byte, error) {
+	var lastErr error
+
 	for {
 		block, rest := pem.Decode(pemContent)
 		if block == nil {
@@ -73,6 +75,7 @@ func getPubKeyFromPemData(pemContent []byte) ([]byte, error) {
 
 		key, err := parseCertificateOrPublicKey(block.Bytes)
 		if err != nil {
+			lastErr = err
 			continue
 		}
 
@@ -80,6 +83,10 @@ func getPubKeyFromPemData(pemContent []byte) ([]byte, error) {
 			Type:  "PUBLIC KEY",
 			Bytes: key,
 		}), nil
+	}
+
+	if lastErr != nil {
+		return nil, fmt.Errorf("no ECDSA public key in pem file: %w", lastErr)
 	}
 
 	return nil, errors.New("no ECDSA public key in pem file")
@@ -90,18 +97,23 @@ func parseCertificateOrPublicKey(blockBytes []byte) ([]byte, error) {
 	cert, err := x509.ParseCertificate(blockBytes)
 	var publicKey any
 	if err == nil {
-		if cert.PublicKey != nil && cert.PublicKeyAlgorithm == x509.ECDSA {
-			publicKey = cert.PublicKey
+		if cert.PublicKeyAlgorithm != x509.ECDSA {
+			return nil, fmt.Errorf("certificate uses %s algorithm, expected ECDSA", cert.PublicKeyAlgorithm)
 		}
+		publicKey = cert.PublicKey
 	} else {
 		// If fails, try reading public key
 		anyPublicKey, err2 := x509.ParsePKIXPublicKey(blockBytes)
-		if err2 == nil && anyPublicKey != nil {
-			var ok bool
-			publicKey, ok = anyPublicKey.(*ecdsa.PublicKey)
-			if !ok {
-				return nil, errors.New("public key is not a ecdsa public key")
-			}
+		if err2 != nil {
+			return nil, fmt.Errorf("failed to parse public key: %w", err2)
+		}
+		if anyPublicKey == nil {
+			return nil, errors.New("public key is nil")
+		}
+		var ok bool
+		publicKey, ok = anyPublicKey.(*ecdsa.PublicKey)
+		if !ok {
+			return nil, errors.New("public key is not an ECDSA public key")
 		}
 	}
 
@@ -111,7 +123,7 @@ func parseCertificateOrPublicKey(blockBytes []byte) ([]byte, error) {
 
 	key, err := x509.MarshalPKIXPublicKey(publicKey)
 	if err != nil {
-		return nil, fmt.Errorf("marshalling public key from failed: %w", err)
+		return nil, fmt.Errorf("marshalling public key failed: %w", err)
 	}
 	return key, nil
 }

--- a/tools/fxconfig/internal/transaction/policy_parse_test.go
+++ b/tools/fxconfig/internal/transaction/policy_parse_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package transaction
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCertificateOrPublicKey_RSACertReturnsAlgorithmError(t *testing.T) {
+	t.Parallel()
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-rsa"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &rsaKey.PublicKey, rsaKey)
+	require.NoError(t, err)
+
+	_, gotErr := parseCertificateOrPublicKey(certDER)
+	require.Error(t, gotErr)
+	require.Contains(t, gotErr.Error(), "certificate uses")
+	require.Contains(t, gotErr.Error(), "expected ECDSA")
+}
+
+func TestParseCertificateOrPublicKey_CorruptBytesReturnsParseError(t *testing.T) {
+	t.Parallel()
+
+	corrupt := []byte("this is definitely not valid ASN.1 DER data")
+	_, gotErr := parseCertificateOrPublicKey(corrupt)
+	require.Error(t, gotErr)
+	require.True(
+		t,
+		strings.Contains(gotErr.Error(), "failed to parse public key") || strings.Contains(gotErr.Error(), "asn1"),
+		"unexpected error: %v",
+		gotErr,
+	)
+}
+
+func TestParseCertificateOrPublicKey_ValidECDSAKeySucceeds(t *testing.T) {
+	t.Parallel()
+
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	pubDER, err := x509.MarshalPKIXPublicKey(&ecKey.PublicKey)
+	require.NoError(t, err)
+
+	result, err := parseCertificateOrPublicKey(pubDER)
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+}
+
+func TestParseCertificateOrPublicKey_ValidECDSACertSucceeds(t *testing.T) {
+	t.Parallel()
+
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test-ecdsa"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &ecKey.PublicKey, ecKey)
+	require.NoError(t, err)
+
+	result, err := parseCertificateOrPublicKey(certDER)
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+}


### PR DESCRIPTION
#### Type of change

- Bug fix
- Test update

#### Description

This change improves the error reporting when parsing threshold policy key material for `fxconfig` commands.

Previously, `parseCertificateOrPublicKey` had two silent failure paths:

- Valid non-ECDSA certificates (for example RSA) caused the function to return a generic “no ECDSA public key in block” error, with no indication that the algorithm was wrong.
- Corrupt or malformed DER bytes caused the underlying ASN.1 parse error from `x509.ParsePKIXPublicKey` to be dropped, again returning only the generic message.

In addition, `getPubKeyFromPemData` would discard these detailed errors while iterating over PEM blocks and eventually return a single generic
`no ECDSA public key in pem file` message to the caller.

This PR:

- Updates `parseCertificateOrPublicKey` to:
  - Return a specific error when a certificate uses a non-ECDSA algorithm, e.g. `certificate uses RSA algorithm, expected ECDSA`.
  - Wrap and propagate parse failures from `x509.ParsePKIXPublicKey` as `failed to parse public key: <underlying error>`.
  - Keep the success path for valid ECDSA public keys and certificates unchanged.
- Updates `getPubKeyFromPemData` to:
  - Track the last parse error encountered across PEM blocks.
  - Wrap and return that error as `no ECDSA public key in pem file: <underlying error>` when no usable key is found.
  - Fall back to the original generic error only when no specific parse error was produced.

With these changes, users of:

- `fxconfig namespace create --threshold-policy <path>`
- `fxconfig namespace update --threshold-policy <path>`

now see clear, actionable error messages that distinguish between algorithm mismatch, corrupt key material, and the absence of any ECDSA key in the file.

#### Additional details (Optional)

The tests are written to be resilient to small differences in Go’s ASN.1 error strings by checking for either the wrapped message prefix (`failed to parse public key`) or the presence of `"asn1"` in the error text.

#### Related issues

- Fixes #239