### PR TITLE
fix(fxconfig/transaction): prevent duplicate endorsements per MSP

### DIFF
--- a/tools/fxconfig/internal/transaction/endorse.go
+++ b/tools/fxconfig/internal/transaction/endorse.go
@@ -71,6 +71,16 @@ func Endorse(signer msp.SigningIdentity, txID string, tx *applicationpb.Tx) (*ap
 			}
 		}
 
+		for _, existing := range tx.Endorsements[nsIdx].EndorsementsWithIdentity {
+			if existing.GetIdentity().GetMspId() == signerIdentity.GetMspId() {
+				return nil, fmt.Errorf(
+					"duplicate endorsement: signer %q already endorsed namespace %d",
+					signerIdentity.GetMspId(),
+					nsIdx,
+				)
+			}
+		}
+
 		tx.Endorsements[nsIdx].EndorsementsWithIdentity = append(tx.Endorsements[nsIdx].EndorsementsWithIdentity, eid)
 	}
 

--- a/tools/fxconfig/internal/transaction/endorse_test.go
+++ b/tools/fxconfig/internal/transaction/endorse_test.go
@@ -187,6 +187,27 @@ func TestEndorse(t *testing.T) {
 	}
 }
 
+func TestEndorse_DuplicateSignerReturnsError(t *testing.T) {
+	t.Parallel()
+
+	tx := &applicationpb.Tx{
+		Namespaces: []*applicationpb.TxNamespace{
+			{NsId: "ns1", NsVersion: 0},
+		},
+	}
+	signer := &mockSigningIdentity{mspID: "Org1MSP"}
+
+	first, err := Endorse(signer, "tx-dup", tx)
+	require.NoError(t, err)
+	require.Len(t, first.Endorsements, 1)
+	require.Len(t, first.Endorsements[0].EndorsementsWithIdentity, 1)
+
+	second, err := Endorse(signer, "tx-dup", first)
+	require.Error(t, err)
+	require.Nil(t, second)
+	require.Contains(t, err.Error(), "duplicate endorsement")
+}
+
 func TestGenerateTxID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!--
Copyright IBM Corp. All Rights Reserved.

SPDX-License-Identifier: Apache-2.0

DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST.

If this PR introduces a breaking change that affects compatibility with other components:
- The PR title must begin with the prefix [BREAKING].
- "Breaking change" must be included in the list below.
- Relevant stakeholders must be notified before or immediately after the PR is merged.
-->
#### Type of change

- Bug fix
- Test update

#### Description

`Endorse` in `tools/fxconfig/internal/transaction/endorse.go` previously only checked whether `tx.Endorsements` was `nil` before appending endorsements. As a result, calling `Endorse` a second time with the same signer on a transaction that already carried endorsements would silently append a second `EndorsementWithIdentity` with the same MSP ID for each namespace, contrary to the intent expressed in the function comment and to the deduplication behavior of `mergeEndorsements`. [web:21]

This PR updates `Endorse` to prevent duplicate endorsements from the same MSP per namespace:

- Before appending a new `EndorsementWithIdentity`, the function now scans existing entries for the current namespace.
- If an existing endorsement with the same `Identity.MspId` is found, `Endorse` returns a descriptive error of the form:
  `duplicate endorsement: signer %q already endorsed namespace %d`.
- If no duplicate is found, the endorsement is appended as before.

This change makes `Endorse` consistent with its own comment (“check that tx does not yet carry any endorsements”) and with `mergeEndorsements`, which already deduplicates endorsements by MSP ID. It also prevents transactions from leaving `Endorse` in a state where the same MSP ID appears more than once for a given namespace, which could cause confusing downstream validation behavior. [web:21]

#### Additional details (Optional)

A new regression test, `TestEndorse_DuplicateSignerReturnsError`, has been added to `tools/fxconfig/internal/transaction/endorse_test.go`. This test:

- Constructs a transaction with a single namespace.
- Calls `Endorse` once with a mock signer (e.g. `Org1MSP`) and asserts that one endorsement is present.
- Calls `Endorse` a second time with the same signer and asserts that:
  - An error is returned.
  - The returned transaction is `nil`.
  - The error message contains `duplicate endorsement`. [web:21]

This ensures the duplicate-protection behavior is exercised and prevents regressions where duplicate endorsements might be silently appended again.

#### Related issues

- Fixes #241