### PR TITLE
fix(fxconfig): prevent reuse of closed gRPC clients in app services

### DIFF
--- a/tools/fxconfig/internal/app/list.go
+++ b/tools/fxconfig/internal/app/list.go
@@ -20,9 +20,6 @@ func (d *AdminApp) ListNamespaces(ctx context.Context) ([]NamespaceQueryResult, 
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = qc.Close()
-	}()
 
 	res, err := qc.GetNamespacePolicies(ctx)
 	if err != nil {

--- a/tools/fxconfig/internal/app/submit.go
+++ b/tools/fxconfig/internal/app/submit.go
@@ -28,9 +28,6 @@ func (d *AdminApp) SubmitTransaction(ctx context.Context, txID string, tx *appli
 	if err != nil {
 		return fmt.Errorf("failed to prepare submission: %w", err)
 	}
-	defer func() {
-		_ = sc.ordererClient.Close()
-	}()
 
 	if err := sc.ordererClient.Broadcast(ctx, sc.signingIdentity, txID, tx); err != nil {
 		return fmt.Errorf("failed to broadcast transaction: %w", err)
@@ -46,9 +43,6 @@ func (d *AdminApp) SubmitTransactionWithWait(ctx context.Context, txID string, t
 	if err != nil {
 		return UnknownStatus, fmt.Errorf("failed to prepare submission: %w", err)
 	}
-	defer func() {
-		_ = sc.ordererClient.Close()
-	}()
 
 	// get notification client
 	nc, err := d.NotificationProvider.Get()
@@ -56,9 +50,6 @@ func (d *AdminApp) SubmitTransactionWithWait(ctx context.Context, txID string, t
 		return UnknownStatus, fmt.Errorf("failed to get notification client: %w", err)
 	}
 
-	defer func() {
-		_ = nc.Close()
-	}()
 
 	subscription, err := nc.Subscribe(ctx, txID)
 	if err != nil {


### PR DESCRIPTION
Fixes: #252 
## Description

Previously, `SubmitTransaction`, `SubmitTransactionWithWait`, and `ListNamespaces` used `defer func() { _ = client.Close() }()` to close the `ordererClient`, `notificationClient`, and `queryClient` after execution. Because these clients are retrieved from a `sync.Once` cached provider, closing the client on the first execution caused all subsequent calls to receive a closed connection.
### Changes Made
*   Removed the `defer client.Close()` blocks in `tools/fxconfig/internal/app/submit.go` and `tools/fxconfig/internal/app/list.go`.
*   The connection lifecycle is now correctly managed by the provider, persisting for the duration of the CLI process as intended.
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## How Has This Been Tested?
- [x] Verified by running the existing `go test -v .` suite inside `tools/fxconfig/internal/app`. All tests passed successfully.
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have signed off on my commit (DCO)