### PR TITLE
 fix(fxconfig): add missing validation for NotificationsConfig and QueriesConfig

### DIFF
--- a/tools/fxconfig/internal/config/validate.go
+++ b/tools/fxconfig/internal/config/validate.go
@@ -40,6 +40,21 @@ func (c *OrdererConfig) Validate(vctx validation.Context) error {
 	return c.EndpointServiceConfig.Validate(vctx)
 }
 
+// Validate validates Queries configuration.
+// Check endpoint service configuration.
+func (c *QueriesConfig) Validate(vctx validation.Context) error {
+	return c.EndpointServiceConfig.Validate(vctx)
+}
+
+// Validate validates Notifications configuration.
+// Check waiting timeout and endpoint service configuration.
+func (c *NotificationsConfig) Validate(vctx validation.Context) error {
+	if c.WaitingTimeout <= 0 {
+		return errors.New("waiting timeout must be greater than zero")
+	}
+	return c.EndpointServiceConfig.Validate(vctx)
+}
+
 // Validate validates service endpoint configuration.
 // Checks address, timeout, and TLS settings for a given service.
 func (c *EndpointServiceConfig) Validate(vctx validation.Context) error {

--- a/tools/fxconfig/internal/config/validate_notifications_test.go
+++ b/tools/fxconfig/internal/config/validate_notifications_test.go
@@ -1,0 +1,138 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric-x/tools/fxconfig/internal/validation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotificationsConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	validTLS := &TLSConfig{Enabled: new(bool)}
+	*validTLS.Enabled = false
+
+	vctx := validation.Context{}
+
+	tests := []struct {
+		name          string
+		cfg           NotificationsConfig
+		expectedError string
+	}{
+		{
+			name: "valid config",
+			cfg: NotificationsConfig{
+				EndpointServiceConfig: EndpointServiceConfig{
+					Address:           "localhost:1234",
+					ConnectionTimeout: 5 * time.Second,
+					TLS:               validTLS,
+				},
+				WaitingTimeout: 30 * time.Second,
+			},
+			expectedError: "",
+		},
+		{
+			name: "zero waiting timeout",
+			cfg: NotificationsConfig{
+				EndpointServiceConfig: EndpointServiceConfig{
+					Address:           "localhost:1234",
+					ConnectionTimeout: 5 * time.Second,
+					TLS:               validTLS,
+				},
+				WaitingTimeout: 0,
+			},
+			expectedError: "waiting timeout must be greater than zero",
+		},
+		{
+			name: "negative waiting timeout",
+			cfg: NotificationsConfig{
+				EndpointServiceConfig: EndpointServiceConfig{
+					Address:           "localhost:1234",
+					ConnectionTimeout: 5 * time.Second,
+					TLS:               validTLS,
+				},
+				WaitingTimeout: -1 * time.Second,
+			},
+			expectedError: "waiting timeout must be greater than zero",
+		},
+		{
+			name: "invalid embedded config",
+			cfg: NotificationsConfig{
+				EndpointServiceConfig: EndpointServiceConfig{
+					Address:           "invalid-address",
+					ConnectionTimeout: 5 * time.Second,
+					TLS:               validTLS,
+				},
+				WaitingTimeout: 30 * time.Second,
+			},
+			expectedError: "invalid address",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.cfg.Validate(vctx)
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestQueriesConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	validTLS := &TLSConfig{Enabled: new(bool)}
+	*validTLS.Enabled = false
+
+	vctx := validation.Context{}
+
+	tests := []struct {
+		name          string
+		cfg           QueriesConfig
+		expectedError string
+	}{
+		{
+			name: "valid config",
+			cfg: QueriesConfig{
+				EndpointServiceConfig: EndpointServiceConfig{
+					Address:           "localhost:1234",
+					ConnectionTimeout: 5 * time.Second,
+					TLS:               validTLS,
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name: "invalid embedded config",
+			cfg: QueriesConfig{
+				EndpointServiceConfig: EndpointServiceConfig{
+					Address:           "invalid-address",
+					ConnectionTimeout: 5 * time.Second,
+					TLS:               validTLS,
+				},
+			},
+			expectedError: "invalid address",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.cfg.Validate(vctx)
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION

Previously, `NotificationsConfig` and `QueriesConfig` embedded `EndpointServiceConfig` but lacked their own `Validate()` methods. When the config validator checked the configuration, it silently fell back to the embedded struct's `Validate()` method. This correctly validated shared fields but completely skipped struct-specific fields. 
Specifically for `NotificationsConfig`, the `WaitingTimeout` field was skipped, allowing users to configure invalid timeouts (`0s` or negative values) which resulted in silent configuration acceptance and subsequent runtime transaction failures.
### Changes Made
*   **Added explicit `Validate` methods:** `NotificationsConfig` and `QueriesConfig` now have explicit `Validate(vctx validation.Context) error` methods in `tools/fxconfig/internal/config/validate.go`.
*   **Struct-Specific Validation:** `NotificationsConfig.Validate()` explicitly checks that `WaitingTimeout` is `> 0` before safely delegating to the embedded `EndpointServiceConfig.Validate()`.
*   **Added comprehensive testing:** Added `tools/fxconfig/internal/config/validate_notifications_test.go` to test positive flows, zero timeouts, negative timeouts, and invalid embedded config structures for both newly validated configs.
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## How Has This Been Tested?
- [x] Ran unit tests for `NotificationsConfig_Validate` ensuring negative and zero values fail.
- [x] Ran unit tests for `QueriesConfig_Validate` ensuring embedded delegation works properly.
- [x] `go test -v .` runs cleanly.
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have signed off on my commit (DCO)

Fixes: #254 