### PR TITLE
chore: replace gopkg.in/yaml.v3 with go.yaml.in/yaml/v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,10 +25,10 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.40.0
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sync v0.19.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -147,7 +147,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
@@ -159,5 +158,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260120221211-b8f7ae30c516 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/gotestsum v1.13.0 // indirect
 )

--- a/tools/fxconfig/internal/cli/v1/cliio/printer.go
+++ b/tools/fxconfig/internal/cli/v1/cliio/printer.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"io"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Format specifies the output format for CLI printing.

--- a/tools/fxconfig/internal/cli/v1/cliio/printer_test.go
+++ b/tools/fxconfig/internal/cli/v1/cliio/printer_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestNewCLIPrinter(t *testing.T) {

--- a/tools/fxconfig/internal/cli/v1/info.go
+++ b/tools/fxconfig/internal/cli/v1/info.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // NewInfoCommand returns a command that displays the effective configuration.


### PR DESCRIPTION
#### Type of change

- Dependency update

#### Description

gopkg.in/yaml.v3 has been archived, thus, switching to go.yaml.in/yaml/v3