### PR TITLE
Add missing mkdocs-multirepo dependency to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,5 +22,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material mkdocs-multirepo
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

The CI workflow only installed mkdocs-material but mkdocs.yml
uses the multirepo plugin, causing deployment to fail with:
  ERROR - Config value 'plugins': The multirepo plugin is not installed
