### PR TITLE
Fix mkdocs-multirepo package name in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,5 +22,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - run: pip install mkdocs-material mkdocs-multirepo
+      - run: pip install mkdocs-material mkdocs-multirepo-plugin
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

mkdocs-multirepo (0.5.2) is an obsolete package that does not
provide the mkdocs plugin entry point. The correct package is
mkdocs-multirepo-plugin which registers the 'multirepo' plugin
via mkdocs_multirepo_plugin.plugin:MultirepoPlugin.
