### PR TITLE
added block explorer image in integration test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,10 @@ on:
         description: "fabric-x-committer ref. Empty=use refs.conf default"
         required: false
         default: ""
+      explorer-ref:
+        description: "fabric-x-block-explorer image tag. Empty=use refs.conf default"
+        required: false
+        default: ""
 
 jobs:
   e2e:
@@ -55,6 +59,7 @@ jobs:
           INPUT_FABRIC_X_REF: ${{ inputs.fabric-x-ref }}
           INPUT_ORDERER_REF: ${{ inputs.orderer-ref }}
           INPUT_COMMITTER_REF: ${{ inputs.committer-ref }}
+          INPUT_EXPLORER_REF: ${{ inputs.explorer-ref }}
         run: |
           args=()
           if [ -n "${INPUT_FABRIC_X_REF}" ]; then
@@ -65,6 +70,9 @@ jobs:
           fi
           if [ -n "${INPUT_COMMITTER_REF}" ]; then
             args+=("--committer-ref=${INPUT_COMMITTER_REF}")
+          fi
+          if [ -n "${INPUT_EXPLORER_REF}" ]; then
+            args+=("--explorer-ref=${INPUT_EXPLORER_REF}")
           fi
 
           ./integration/test/build-e2e.sh "${args[@]}"
@@ -77,6 +85,8 @@ jobs:
           ORDERER_IMAGE: ${{ steps.images.outputs.orderer_image }}
           COMMITTER_IMAGE: ${{ steps.images.outputs.committer_image }}
           LOADGEN_IMAGE: ${{ steps.images.outputs.loadgen_image }}
+          EXPLORER_IMAGE: ${{ steps.images.outputs.explorer_image }}
+          EXPLORER_AVAILABLE: ${{ steps.images.outputs.explorer_available }}
           FABRIC_X_BIN: ${{ github.workspace }}/integration/test/.build/fabric-x/bin
           SKIP_CLEANUP_PROMPT: "1"
         run: ./integration/test/run-e2e.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ on:
         required: false
         default: ""
       explorer-ref:
-        description: "fabric-x-block-explorer image tag. Empty=use refs.conf default"
+        description: "fabric-x-block-explorer ref. Empty=use refs.conf default"
         required: false
         default: ""
 
@@ -86,7 +86,6 @@ jobs:
           COMMITTER_IMAGE: ${{ steps.images.outputs.committer_image }}
           LOADGEN_IMAGE: ${{ steps.images.outputs.loadgen_image }}
           EXPLORER_IMAGE: ${{ steps.images.outputs.explorer_image }}
-          EXPLORER_AVAILABLE: ${{ steps.images.outputs.explorer_available }}
           FABRIC_X_BIN: ${{ github.workspace }}/integration/test/.build/fabric-x/bin
           SKIP_CLEANUP_PROMPT: "1"
         run: ./integration/test/run-e2e.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,8 +5,9 @@
 #
 # E2E Integration Test workflow.
 #
-# Uses integration/test/build-e2e.sh to build orderer+committer+loadgen images
-# and runs the full E2E pipeline test.
+# Uses integration/test/build-e2e.sh to build all component images
+# (orderer, committer, loadgen, explorer) and fabric-x tools, then
+# runs the full E2E pipeline test.
 # All refs default to values in integration/test/refs.conf when not provided.
 #
 
@@ -47,11 +48,11 @@ jobs:
           go-version-file: go.mod
 
       # ---------------------------------------------------------------
-      # Resolve/build orderer+committer images and fabric-x tools.
-      # build-e2e.sh writes orderer_image and committer_image to
-      # GITHUB_OUTPUT so downstream steps can reference them directly.
-      # It also builds fabric-x tools (cryptogen, configtxgen, fxconfig)
-      # at the specified fabric-x-ref for artifact generation.
+      # Build all component images (orderer, committer, loadgen, explorer)
+      # and fabric-x tools (cryptogen, configtxgen, fxconfig).
+      # build-e2e.sh clones each repo at the configured ref, builds the
+      # image locally, and writes resolved image names to GITHUB_OUTPUT
+      # so downstream steps can reference them without parsing stdout.
       # ---------------------------------------------------------------
       - name: Build E2E images and tools
         id: images

--- a/integration/test/README.md
+++ b/integration/test/README.md
@@ -101,6 +101,8 @@ SKIP_CLEANUP_PROMPT=1 ./run-e2e.sh
 | `COMMITTER_IMAGE` | `docker.io/hyperledger/${COMMITTER_IMAGE_NAME}:${COMMITTER_REF}` | Resolved from `refs.conf` |
 | `LOADGEN_IMAGE` | `docker.io/hyperledger/fabric-x-loadgen:${COMMITTER_REF}` | Versioned with `COMMITTER_REF` |
 | `FABRIC_X_BIN` | `integration/test/.build/fabric-x/bin` | Built by `build-e2e.sh` |
+| `EXPLORER_IMAGE` | `ghcr.io/lf-decentralized-trust-labs/fabric-x-block-explorer:latest` | Pulled as `:latest` — non-blocking if unavailable |
+| `EXPLORER_AVAILABLE` | `false` | Set to `true` by `build-e2e.sh` when pull succeeds |
 
 **Steps performed:**
 
@@ -114,7 +116,9 @@ SKIP_CLEANUP_PROMPT=1 ./run-e2e.sh
 8. Create namespace using `fxconfig` with multi-org endorsement (both peer-org-0 and peer-org-1 sign)
 9. Run loadgen (submits ~10,000 TXs)
 10. Verify >= 5000 committed transactions via VC Prometheus metrics
-11. Prompt user before cleanup (so they can view Grafana dashboards)
+11. Explorer smoke check — start explorer + postgres, wait for /healthz (non-blocking)
+12. Explorer block ingestion check — poll /blocks/height > 0 (non-blocking)
+13. Prompt user before cleanup (so they can view Grafana dashboards)
 
 ### `clean.sh`
 
@@ -267,6 +271,8 @@ integration/test/
 │   ├── verifier.yaml           #   Transaction signature verification
 │   ├── vc.yaml                 #   Read-set validation + DB commit
 │   └── query.yaml              #   Read-only state access
+├── explorerconfig/             # Explorer config files (mounted into explorer container)
+│   └── explorer.yaml           #   DB + sidecar + REST server config
 ├── prometheus/                 # Prometheus configuration
 │   └── prometheus.yml          #   Scrape targets for all Fabric-X services
 └── grafana/                    # Grafana dashboards and provisioning

--- a/integration/test/README.md
+++ b/integration/test/README.md
@@ -72,15 +72,17 @@ All refs and image names default to values in `refs.conf` and can be overridden 
 | `--fabric-x-ref=REF` | Tag, branch, or commit for fabric-x tools |
 | `--committer-ref=REF` | Tag, branch, or commit for fabric-x-committer |
 | `--orderer-ref=REF` | Tag, branch, or commit for fabric-x-orderer |
+| `--explorer-ref=REF` | Tag, branch, or commit for fabric-x-block-explorer |
 | `--fabric-x-repo=URL` | Override default fabric-x GitHub repo URL |
 | `--committer-repo=URL` | Override default committer GitHub repo URL |
 | `--orderer-repo=URL` | Override default orderer GitHub repo URL |
+| `--explorer-repo=URL` | Override default explorer GitHub repo URL |
 
 On completion, the script prints the resolved image tags used by `run-e2e.sh`. In GitHub Actions, the resolved image names are also written to `GITHUB_OUTPUT`.
 
 ### `run-e2e.sh`
 
-Runs the full E2E test. Generates all artifacts on the host, starts containers, runs the loadgen, and verifies that >= 5000 transactions were committed.
+Runs the full E2E test. Generates all artifacts on the host, starts containers, runs the loadgen, and verifies that >= 10002 transactions were committed.
 
 ```bash
 # Use refs and image names from refs.conf (monitoring enabled by default)
@@ -101,8 +103,7 @@ SKIP_CLEANUP_PROMPT=1 ./run-e2e.sh
 | `COMMITTER_IMAGE` | `docker.io/hyperledger/${COMMITTER_IMAGE_NAME}:${COMMITTER_REF}` | Resolved from `refs.conf` |
 | `LOADGEN_IMAGE` | `docker.io/hyperledger/fabric-x-loadgen:${COMMITTER_REF}` | Versioned with `COMMITTER_REF` |
 | `FABRIC_X_BIN` | `integration/test/.build/fabric-x/bin` | Built by `build-e2e.sh` |
-| `EXPLORER_IMAGE` | `ghcr.io/lf-decentralized-trust-labs/fabric-x-block-explorer:latest` | Pulled as `:latest` — non-blocking if unavailable |
-| `EXPLORER_AVAILABLE` | `false` | Set to `true` by `build-e2e.sh` when pull succeeds |
+| `EXPLORER_IMAGE` | `localhost/fabric-x-block-explorer:${EXPLORER_REF}` | Built locally by `build-e2e.sh` |
 
 **Steps performed:**
 
@@ -115,10 +116,10 @@ SKIP_CLEANUP_PROMPT=1 ./run-e2e.sh
 7. Wait for health (router port 6022, batcher port 6024, sidecar port 4001)
 8. Create namespace using `fxconfig` with multi-org endorsement (both peer-org-0 and peer-org-1 sign)
 9. Run loadgen (submits ~10,000 TXs)
-10. Verify >= 5000 committed transactions via VC Prometheus metrics
+10. Verify >= 10002 committed transactions via VC Prometheus metrics
 11. Explorer smoke check — start explorer + postgres, wait for /healthz (non-blocking)
-12. Explorer block ingestion check — poll /blocks/height > 0 (non-blocking)
-13. Prompt user before cleanup (so they can view Grafana dashboards)
+12. Explorer transaction count check — poll /blocks and verify total tx_count >= 10002 (non-blocking)
+13. Prompt user before cleanup (so they can view Grafana dashboards and block explorer)
 
 ### `clean.sh`
 

--- a/integration/test/README.md
+++ b/integration/test/README.md
@@ -18,14 +18,14 @@ Loadgen → Arma Routers (BFT broadcast)
 - Docker (with compose plugin)
 - `cryptogen`, `configtxgen`, and `fxconfig` built from this repo (`make tools` from fabric-x root)
 - `curl` and `nc` (netcat) on the host
-- Docker images: `arma-4p1s`, `committer-test-node`, `fabric-x-loadgen`
+- Docker images built by `build-e2e.sh`: `arma-4p1s`, `committer-test-node`, `fabric-x-loadgen`, `fabric-x-block-explorer`
 
 ## Quick Start
 
 ```bash
 cd integration/test
 
-# Build/resolve orderer + committer images and tools
+# Build all component images (orderer, committer, loadgen, explorer) and tools
 ./build-e2e.sh
 
 # Run the test
@@ -36,11 +36,11 @@ cd integration/test
 
 ### `build-e2e.sh`
 
-Builds the orderer (`arma-4p1s`) and committer (`committer-test-node`) Docker images needed by `run-e2e.sh`. Also clones fabric-x at a specific ref to build host tools (`cryptogen`, `configtxgen`, `fxconfig`).
+Builds all Docker images needed by `run-e2e.sh`: orderer (`arma-4p1s`), committer (`committer-test-node`), loadgen (`fabric-x-loadgen`), and explorer (`fabric-x-block-explorer`). Also clones fabric-x at a specific ref to build host tools (`cryptogen`, `configtxgen`, `fxconfig`).
 
 Image build strategy per component:
 
-1. **Local build** — clones the component repo at the specified ref and builds locally.
+1. **Local build** — clones the component repo at the specified ref (or copies from a local path) and builds locally.
 2. **Tag normalization** — tags local images with the refs from `refs.conf` so `run-e2e.sh` can resolve them deterministically.
 
 All refs and image names default to values in `refs.conf` and can be overridden via CLI flags.
@@ -55,11 +55,20 @@ All refs and image names default to values in `refs.conf` and can be overridden 
 # Build orderer from a specific commit hash
 ./build-e2e.sh --orderer-ref=abc123
 
-# Build both from refs
+# Build explorer from a specific tag
+./build-e2e.sh --explorer-ref=v0.2.0
+
+# Build both committer and orderer from refs
 ./build-e2e.sh --orderer-ref=main --committer-ref=my-feature-branch
 
-# Use a custom repo URL (e.g., a fork)
+# Use a custom repo URL for committer (e.g., a fork)
 ./build-e2e.sh --committer-repo=https://github.com/myorg/fabric-x-committer.git --committer-ref=my-branch
+
+# Use a custom repo URL for explorer (e.g., a fork)
+./build-e2e.sh --explorer-repo=https://github.com/myorg/fabric-x-block-explorer.git --explorer-ref=my-branch
+
+# Build explorer from a local working copy
+./build-e2e.sh --explorer-local-path=../fabric-x-block-explorer --explorer-ref=dev
 
 # Then run the test
 ./run-e2e.sh
@@ -77,6 +86,10 @@ All refs and image names default to values in `refs.conf` and can be overridden 
 | `--committer-repo=URL` | Override default committer GitHub repo URL |
 | `--orderer-repo=URL` | Override default orderer GitHub repo URL |
 | `--explorer-repo=URL` | Override default explorer GitHub repo URL |
+| `--fabric-x-local-path=PATH` | Build fabric-x tools from local working copy |
+| `--committer-local-path=PATH` | Build committer/loadgen from local working copy |
+| `--orderer-local-path=PATH` | Build orderer from local working copy |
+| `--explorer-local-path=PATH` | Build explorer from local working copy |
 
 On completion, the script prints the resolved image tags used by `run-e2e.sh`. In GitHub Actions, the resolved image names are also written to `GITHUB_OUTPUT`.
 
@@ -85,11 +98,14 @@ On completion, the script prints the resolved image tags used by `run-e2e.sh`. I
 Runs the full E2E test. Generates all artifacts on the host, starts containers, runs the loadgen, and verifies that >= 10002 transactions were committed.
 
 ```bash
-# Use refs and image names from refs.conf (monitoring enabled by default)
+# Use refs and image names from refs.conf (monitoring and explorer enabled by default)
 ./run-e2e.sh
 
 # Disable monitoring stack
 ENABLE_MONITORING=false ./run-e2e.sh
+
+# Disable block explorer
+ENABLE_EXPLORER=false ./run-e2e.sh
 
 # Skip the cleanup prompt (e.g., for CI)
 SKIP_CLEANUP_PROMPT=1 ./run-e2e.sh
@@ -112,13 +128,13 @@ SKIP_CLEANUP_PROMPT=1 ./run-e2e.sh
 3. Generate orderer local configs from templates
 4. Generate channel genesis block (`configtxgen`)
 5. Start Arma orderer and committer containers
-6. Start Prometheus + Grafana monitoring stack
-7. Wait for health (router port 6022, batcher port 6024, sidecar port 4001)
-8. Create namespace using `fxconfig` with multi-org endorsement (both peer-org-0 and peer-org-1 sign)
-9. Run loadgen (submits ~10,000 TXs)
-10. Verify >= 10002 committed transactions via VC Prometheus metrics
-11. Explorer smoke check — start explorer + postgres, wait for /healthz (non-blocking)
-12. Explorer transaction count check — poll /blocks and verify total tx_count >= 10002 (non-blocking)
+6. Start Prometheus + Grafana monitoring stack (skipped when `ENABLE_MONITORING=false`)
+7. Start block explorer + postgres (skipped when `ENABLE_EXPLORER=false`)
+8. Wait for health (router port 6022, batcher port 6024, sidecar port 4001, explorer port 8080)
+9. Create namespace using `fxconfig` with multi-org endorsement (both peer-org-0 and peer-org-1 sign)
+10. Run loadgen (submits ~10,000 TXs)
+11. Verify >= 10002 committed transactions via VC Prometheus metrics
+12. Verify block explorer — wait for `/healthz`, then confirm tx count >= 10002 (skipped when `ENABLE_EXPLORER=false`)
 13. Prompt user before cleanup (so they can view Grafana dashboards and block explorer)
 
 ### `clean.sh`
@@ -142,7 +158,7 @@ You can run the GitHub Actions workflow from github.com or with the GitHub CLI.
 1. Open: `https://github.com/hyperledger/fabric-x/actions/workflows/e2e.yml`
 2. Click **Run workflow**.
 3. Select the branch that contains your workflow/code changes.
-4. Enter `fabric-x-ref`, `orderer-ref`, and `committer-ref` (or leave empty for refs.conf defaults).
+4. Enter `fabric-x-ref`, `orderer-ref`, `committer-ref`, and `explorer-ref` (or leave empty for refs.conf defaults).
 5. Click **Run workflow**.
 
 ### Workflow inputs
@@ -152,10 +168,11 @@ You can run the GitHub Actions workflow from github.com or with the GitHub CLI.
 | `fabric-x-ref` | Ref for `fabric-x` tools (cryptogen, configtxgen, fxconfig). `""` = refs.conf default |
 | `orderer-ref` | Ref for `fabric-x-orderer` (`""` = refs.conf default; any ref is built from source) |
 | `committer-ref` | Ref for `fabric-x-committer` (`""` = refs.conf default; any ref is built from source) |
+| `explorer-ref` | Ref for `fabric-x-block-explorer` (`""` = refs.conf default; any ref is built from source) |
 
 Notes:
 
-- The workflow delegates orderer + committer image resolution/build and tools build to `integration/test/build-e2e.sh`.
+- The workflow delegates all image builds and tools build to `integration/test/build-e2e.sh`.
 - `build-e2e.sh` writes resolved image names to `GITHUB_OUTPUT` for downstream workflow steps.
 - The loadgen image tag matches the committer-ref (explicit or from refs.conf).
 - The fabric-x tools (cryptogen, configtxgen, fxconfig) are built at the specified `fabric-x-ref` and placed in `integration/test/.build/fabric-x/bin`.
@@ -170,25 +187,29 @@ gh workflow run e2e.yml
 gh workflow run e2e.yml \
   -f fabric-x-ref=abc123 \
   -f orderer-ref=f1dfdd7b4e3c5d9ff6c1843da0bf78155262d4f2 \
-  -f committer-ref=d35655cc
+  -f committer-ref=d35655cc \
+  -f explorer-ref=e7a91f2c
 
 # 3) Build all components from release tags
 gh workflow run e2e.yml \
   -f fabric-x-ref=v1.0.0 \
   -f orderer-ref=v1.2.3 \
-  -f committer-ref=v1.2.3
+  -f committer-ref=v1.2.3 \
+  -f explorer-ref=v0.1.0
 
 # 4) Build all components from branch names
 gh workflow run e2e.yml \
   -f fabric-x-ref=main \
   -f orderer-ref=main \
-  -f committer-ref=feature/e2e-fix
+  -f committer-ref=feature/e2e-fix \
+  -f explorer-ref=main
 
-# 5) Mixed: tools from tag, orderer from commit, committer from tag
+# 5) Mixed: tools from tag, orderer from commit, committer from tag, explorer from branch
 gh workflow run e2e.yml \
   -f fabric-x-ref=v1.0.0 \
   -f orderer-ref=f1dfdd7b4e3c5d9ff6c1843da0bf78155262d4f2 \
-  -f committer-ref=v1.2.3
+  -f committer-ref=v1.2.3 \
+  -f explorer-ref=fix/ingest-bug
 
 # 6) Test with specific fabric-x tools version only
 gh workflow run e2e.yml \
@@ -238,9 +259,10 @@ The E2E test deploys a monitoring stack by default with Prometheus and Grafana c
 | Variable | Default | Description |
 |---|---|---|
 | `ENABLE_MONITORING` | `true` | Set to `false` to skip Prometheus + Grafana deployment |
+| `ENABLE_EXPLORER` | `true` | Set to `false` to skip block explorer + postgres deployment |
 | `SKIP_CLEANUP_PROMPT` | _(unset)_ | Set to `1` to skip the post-test cleanup prompt (e.g., CI) |
 
-**On test success**, the script pauses before cleanup and prints the Grafana/Prometheus URLs so you can explore the dashboards. Press ENTER to proceed with cleanup, or Ctrl+C to leave everything running.
+**On test success**, the script pauses before cleanup and prints the Grafana/Prometheus/Explorer URLs so you can explore the dashboards and block data. Press ENTER to proceed with cleanup, or Ctrl+C to leave everything running.
 
 ## Directory Structure
 
@@ -346,3 +368,10 @@ The test runs a 4-party Arma orderer with 1 shard. All 16 orderer processes (4 p
 |---|---|---|
 | 3000 | Grafana | Dashboard UI |
 | 9090 | Prometheus | Metrics query UI |
+
+**Block explorer ports:**
+
+| Port | Service | Purpose |
+|---|---|---|
+| 8080 | Explorer | REST API + `/healthz` + Swagger UI (`/docs`) |
+| 5432 | Postgres | Explorer backing store (internal, not exposed to host) |

--- a/integration/test/build-e2e.sh
+++ b/integration/test/build-e2e.sh
@@ -6,9 +6,9 @@
 #
 # Build Docker images for E2E integration testing.
 #
-# This script builds the orderer (arma-4p1s) and committer (committer-test-node)
-# Docker images needed by run-e2e.sh. It clones the repos at specific refs
-# and builds the images locally.
+# This script builds the orderer (arma-4p1s), committer (committer-test-node),
+# loadgen, and explorer (fabric-x-block-explorer) Docker images needed by
+# run-e2e.sh. It clones each repo at the specified ref and builds locally.
 #
 # Usage:
 #   ./build-e2e.sh                              # build using refs from refs.conf
@@ -21,6 +21,7 @@
 #   ./build-e2e.sh --fabric-x-local-path=PATH   # build fabric-x tools from local working copy
 #   ./build-e2e.sh --orderer-local-path=PATH    # build orderer from local working copy
 #   ./build-e2e.sh --committer-local-path=PATH  # build committer from local working copy
+#   ./build-e2e.sh --explorer-local-path=PATH   # build explorer from local working copy
 #
 # Output:
 #   Prints image names for ORDERER_IMAGE, COMMITTER_IMAGE, LOADGEN_IMAGE, and EXPLORER_IMAGE.
@@ -71,6 +72,7 @@ for arg in "$@"; do
   --fabric-x-local-path=*) FABRIC_X_LOCAL_PATH="${arg#*=}" ;;
   --committer-local-path=*) COMMITTER_LOCAL_PATH="${arg#*=}" ;;
   --orderer-local-path=*) ORDERER_LOCAL_PATH="${arg#*=}" ;;
+  --explorer-local-path=*) EXPLORER_LOCAL_PATH="${arg#*=}" ;;
   --help)
     echo "Usage: ./build-e2e.sh [OPTIONS]"
     echo ""
@@ -86,6 +88,7 @@ for arg in "$@"; do
     echo "  --fabric-x-local-path=PATH  Build fabric-x tools from local working copy"
     echo "  --committer-local-path=PATH Build committer/loadgen from local working copy"
     echo "  --orderer-local-path=PATH   Build orderer from local working copy"
+    echo "  --explorer-local-path=PATH  Build explorer from local working copy"
     echo ""
     echo "Refs are loaded from refs.conf by default and can be overridden via CLI."
     exit 0
@@ -114,7 +117,6 @@ require_var "ORDERER_IMAGE_NAME" "ORDERER_IMAGE_NAME is not set. Check refs.conf
 require_var "COMMITTER_IMAGE_NAME" "COMMITTER_IMAGE_NAME is not set. Check refs.conf"
 require_var "LOADGEN_IMAGE_NAME" "LOADGEN_IMAGE_NAME is not set. Check refs.conf"
 require_var "EXPLORER_IMAGE_NAME" "EXPLORER_IMAGE_NAME is not set. Check refs.conf"
-require_var "EXPLORER_REPO" "EXPLORER_REPO is not set. Check refs.conf"
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Helper functions
@@ -228,12 +230,21 @@ docker build \
   "${COMMITTER_DIR}"
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Build explorer image
-# Clone the explorer repo at the configured ref and build the image locally,
-# consistent with how orderer and committer images are built.
+# Build explorer image (fabric-x-block-explorer)
+#
+# The explorer image packages the block explorer server (REST API + /healthz),
+# the block ingestion worker (connects to the committer sidecar), and the
+# Swagger UI (/docs) into a single container. It uses the Dockerfile at the
+# root of the explorer repo and is started via "start --config /config/explorer.yaml".
+# Supports --explorer-local-path for local fork/branch testing.
+#
+# The explorer is published under the LF-Decentralized-Trust-labs org (not
+# hyperledger), so the image is tagged under localhost/ rather than
+# docker.io/hyperledger/. run-e2e.sh resolves the same localhost/ tag from
+# refs.conf, so no registry pull is needed.
 # ──────────────────────────────────────────────────────────────────────────────
 EXPLORER_DIR="${BUILD_DIR}/fabric-x-block-explorer"
-clone_at_ref "${EXPLORER_REPO}" "${EXPLORER_REF}" "${EXPLORER_DIR}"
+checkout_source "${EXPLORER_REPO}" "${EXPLORER_REF}" "${EXPLORER_DIR}" "${EXPLORER_LOCAL_PATH:-}" "fabric-x-block-explorer"
 
 EXPLORER_IMAGE="localhost/${EXPLORER_IMAGE_NAME}:${EXPLORER_REF}"
 echo "Building ${EXPLORER_IMAGE_NAME} image from ${EXPLORER_DIR}..."

--- a/integration/test/build-e2e.sh
+++ b/integration/test/build-e2e.sh
@@ -15,7 +15,8 @@
 #   ./build-e2e.sh --fabric-x-ref=abc123        # override fabric-x tools ref
 #   ./build-e2e.sh --committer-ref=v1.2.3       # override committer ref
 #   ./build-e2e.sh --orderer-ref=abc123         # override orderer ref
-#   ./build-e2e.sh --explorer-ref=v1.0.0        # override explorer image tag
+#   ./build-e2e.sh --explorer-ref=v1.0.0        # override explorer ref
+#   ./build-e2e.sh --explorer-repo=URL          # custom explorer repo URL
 #   ./build-e2e.sh --fabric-x-repo=URL          # custom fabric-x repo URL
 #   ./build-e2e.sh --fabric-x-local-path=PATH   # build fabric-x tools from local working copy
 #   ./build-e2e.sh --orderer-local-path=PATH    # build orderer from local working copy
@@ -66,6 +67,7 @@ for arg in "$@"; do
   --fabric-x-repo=*) FABRIC_X_REPO="${arg#*=}" ;;
   --committer-repo=*) COMMITTER_REPO="${arg#*=}" ;;
   --orderer-repo=*) ORDERER_REPO="${arg#*=}" ;;
+  --explorer-repo=*) EXPLORER_REPO="${arg#*=}" ;;
   --fabric-x-local-path=*) FABRIC_X_LOCAL_PATH="${arg#*=}" ;;
   --committer-local-path=*) COMMITTER_LOCAL_PATH="${arg#*=}" ;;
   --orderer-local-path=*) ORDERER_LOCAL_PATH="${arg#*=}" ;;
@@ -76,10 +78,11 @@ for arg in "$@"; do
     echo "  --fabric-x-ref=REF          Tag, branch, or commit for fabric-x tools"
     echo "  --committer-ref=REF         Tag, branch, or commit for fabric-x-committer"
     echo "  --orderer-ref=REF           Tag, branch, or commit for fabric-x-orderer"
-    echo "  --explorer-ref=REF          Tag for the explorer image (default: refs.conf)"
+    echo "  --explorer-ref=REF          Tag, branch, or commit for fabric-x-explorer"
     echo "  --fabric-x-repo=URL         Override default fabric-x GitHub repo URL"
     echo "  --committer-repo=URL        Override default committer GitHub repo URL"
     echo "  --orderer-repo=URL          Override default orderer GitHub repo URL"
+    echo "  --explorer-repo=URL         Override default explorer GitHub repo URL"
     echo "  --fabric-x-local-path=PATH  Build fabric-x tools from local working copy"
     echo "  --committer-local-path=PATH Build committer/loadgen from local working copy"
     echo "  --orderer-local-path=PATH   Build orderer from local working copy"
@@ -225,19 +228,16 @@ docker build \
   "${COMMITTER_DIR}"
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Pull explorer image
-# The explorer is independently released; pull it at the configured ref.
-# If the pull fails the E2E test continues without the explorer smoke check.
+# Build explorer image
+# Clone the explorer repo at the configured ref and build the image locally,
+# consistent with how orderer and committer images are built.
 # ──────────────────────────────────────────────────────────────────────────────
-EXPLORER_IMAGE="${EXPLORER_REPO}/${EXPLORER_IMAGE_NAME}:${EXPLORER_REF}"
-EXPLORER_AVAILABLE="false"
-echo "Pulling explorer image: ${EXPLORER_IMAGE}..."
-if docker pull "${EXPLORER_IMAGE}" 2>/dev/null; then
-  EXPLORER_AVAILABLE="true"
-  echo "  ✅ ${EXPLORER_IMAGE}"
-else
-  echo "  ⚠️  Explorer image unavailable — smoke check will be skipped"
-fi
+EXPLORER_DIR="${BUILD_DIR}/fabric-x-block-explorer"
+clone_at_ref "${EXPLORER_REPO}" "${EXPLORER_REF}" "${EXPLORER_DIR}"
+
+EXPLORER_IMAGE="localhost/${EXPLORER_IMAGE_NAME}:${EXPLORER_REF}"
+echo "Building ${EXPLORER_IMAGE_NAME} image from ${EXPLORER_DIR}..."
+docker build -t "${EXPLORER_IMAGE}" "${EXPLORER_DIR}"
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Summary
@@ -252,7 +252,7 @@ echo "Resolved images for run-e2e.sh:"
 echo "  ${ORDERER_IMAGE}"
 echo "  ${COMMITTER_IMAGE}"
 echo "  ${LOADGEN_IMAGE}"
-echo "  ${EXPLORER_IMAGE} (available=${EXPLORER_AVAILABLE})"
+echo "  ${EXPLORER_IMAGE}"
 
 # When running in GitHub Actions, write resolved image names to GITHUB_OUTPUT
 # so downstream workflow steps can reference them without parsing stdout.
@@ -261,5 +261,4 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "committer_image=${COMMITTER_IMAGE}" >>"${GITHUB_OUTPUT}"
   echo "loadgen_image=${LOADGEN_IMAGE}" >>"${GITHUB_OUTPUT}"
   echo "explorer_image=${EXPLORER_IMAGE}" >>"${GITHUB_OUTPUT}"
-  echo "explorer_available=${EXPLORER_AVAILABLE}" >>"${GITHUB_OUTPUT}"
 fi

--- a/integration/test/build-e2e.sh
+++ b/integration/test/build-e2e.sh
@@ -15,13 +15,14 @@
 #   ./build-e2e.sh --fabric-x-ref=abc123        # override fabric-x tools ref
 #   ./build-e2e.sh --committer-ref=v1.2.3       # override committer ref
 #   ./build-e2e.sh --orderer-ref=abc123         # override orderer ref
+#   ./build-e2e.sh --explorer-ref=v1.0.0        # override explorer image tag
 #   ./build-e2e.sh --fabric-x-repo=URL          # custom fabric-x repo URL
 #   ./build-e2e.sh --fabric-x-local-path=PATH   # build fabric-x tools from local working copy
 #   ./build-e2e.sh --orderer-local-path=PATH    # build orderer from local working copy
 #   ./build-e2e.sh --committer-local-path=PATH  # build committer from local working copy
 #
 # Output:
-#   Prints export commands for ORDERER_IMAGE and COMMITTER_IMAGE.
+#   Prints image names for ORDERER_IMAGE, COMMITTER_IMAGE, LOADGEN_IMAGE, and EXPLORER_IMAGE.
 #   When GITHUB_OUTPUT is set (CI), also writes image names there.
 #
 set -euo pipefail
@@ -61,6 +62,7 @@ for arg in "$@"; do
   --fabric-x-ref=*) FABRIC_X_REF="${arg#*=}" ;;
   --committer-ref=*) COMMITTER_REF="${arg#*=}" ;;
   --orderer-ref=*) ORDERER_REF="${arg#*=}" ;;
+  --explorer-ref=*) EXPLORER_REF="${arg#*=}" ;;
   --fabric-x-repo=*) FABRIC_X_REPO="${arg#*=}" ;;
   --committer-repo=*) COMMITTER_REPO="${arg#*=}" ;;
   --orderer-repo=*) ORDERER_REPO="${arg#*=}" ;;
@@ -71,15 +73,16 @@ for arg in "$@"; do
     echo "Usage: ./build-e2e.sh [OPTIONS]"
     echo ""
     echo "Options:"
-    echo "  --fabric-x-ref=REF    Tag, branch, or commit for fabric-x tools"
-    echo "  --committer-ref=REF   Tag, branch, or commit for fabric-x-committer"
-    echo "  --orderer-ref=REF     Tag, branch, or commit for fabric-x-orderer"
-    echo "  --fabric-x-repo=URL        Override default fabric-x GitHub repo URL"
-    echo "  --committer-repo=URL       Override default committer GitHub repo URL"
-    echo "  --orderer-repo=URL         Override default orderer GitHub repo URL"
-    echo "  --fabric-x-local-path=PATH Build fabric-x tools from local working copy"
+    echo "  --fabric-x-ref=REF          Tag, branch, or commit for fabric-x tools"
+    echo "  --committer-ref=REF         Tag, branch, or commit for fabric-x-committer"
+    echo "  --orderer-ref=REF           Tag, branch, or commit for fabric-x-orderer"
+    echo "  --explorer-ref=REF          Tag for the explorer image (default: refs.conf)"
+    echo "  --fabric-x-repo=URL         Override default fabric-x GitHub repo URL"
+    echo "  --committer-repo=URL        Override default committer GitHub repo URL"
+    echo "  --orderer-repo=URL          Override default orderer GitHub repo URL"
+    echo "  --fabric-x-local-path=PATH  Build fabric-x tools from local working copy"
     echo "  --committer-local-path=PATH Build committer/loadgen from local working copy"
-    echo "  --orderer-local-path=PATH  Build orderer from local working copy"
+    echo "  --orderer-local-path=PATH   Build orderer from local working copy"
     echo ""
     echo "Refs are loaded from refs.conf by default and can be overridden via CLI."
     exit 0
@@ -103,9 +106,12 @@ require_var() {
 require_var "FABRIC_X_REF" "FABRIC_X_REF is not set. Please specify --fabric-x-ref or set it in refs.conf"
 require_var "COMMITTER_REF" "COMMITTER_REF is not set. Please specify --committer-ref or set it in refs.conf"
 require_var "ORDERER_REF" "ORDERER_REF is not set. Please specify --orderer-ref or set it in refs.conf"
+require_var "EXPLORER_REF" "EXPLORER_REF is not set. Please specify --explorer-ref or set it in refs.conf"
 require_var "ORDERER_IMAGE_NAME" "ORDERER_IMAGE_NAME is not set. Check refs.conf"
 require_var "COMMITTER_IMAGE_NAME" "COMMITTER_IMAGE_NAME is not set. Check refs.conf"
 require_var "LOADGEN_IMAGE_NAME" "LOADGEN_IMAGE_NAME is not set. Check refs.conf"
+require_var "EXPLORER_IMAGE_NAME" "EXPLORER_IMAGE_NAME is not set. Check refs.conf"
+require_var "EXPLORER_REPO" "EXPLORER_REPO is not set. Check refs.conf"
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Helper functions
@@ -219,24 +225,18 @@ docker build \
   "${COMMITTER_DIR}"
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Pull explorer image (:latest — independently released, non-blocking)
+# Pull explorer image
+# The explorer is independently released; pull it at the configured ref.
 # If the pull fails the E2E test continues without the explorer smoke check.
 # ──────────────────────────────────────────────────────────────────────────────
-EXPLORER_IMAGE="${EXPLORER_REPO:-}/${EXPLORER_IMAGE_NAME:-}:latest"
+EXPLORER_IMAGE="${EXPLORER_REPO}/${EXPLORER_IMAGE_NAME}:${EXPLORER_REF}"
 EXPLORER_AVAILABLE="false"
-if [[ -n "${EXPLORER_REPO:-}" && -n "${EXPLORER_IMAGE_NAME:-}" ]]; then
-  echo "Pulling explorer image: ${EXPLORER_IMAGE}..."
-  if docker pull "${EXPLORER_IMAGE}" 2>/dev/null; then
-    EXPLORER_AVAILABLE="true"
-    echo "  ✅ ${EXPLORER_IMAGE}"
-  else
-    echo "  ⚠️  Explorer image unavailable — smoke check will be skipped"
-  fi
-fi
-
-if [ -n "${GITHUB_OUTPUT:-}" ]; then
-  echo "explorer_image=${EXPLORER_IMAGE}" >> "${GITHUB_OUTPUT}"
-  echo "explorer_available=${EXPLORER_AVAILABLE}" >> "${GITHUB_OUTPUT}"
+echo "Pulling explorer image: ${EXPLORER_IMAGE}..."
+if docker pull "${EXPLORER_IMAGE}" 2>/dev/null; then
+  EXPLORER_AVAILABLE="true"
+  echo "  ✅ ${EXPLORER_IMAGE}"
+else
+  echo "  ⚠️  Explorer image unavailable — smoke check will be skipped"
 fi
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -248,10 +248,11 @@ echo "Run the E2E test with:"
 echo ""
 echo "  ./run-e2e.sh"
 echo ""
-echo "Resolved local tags for run-e2e.sh:"
+echo "Resolved images for run-e2e.sh:"
 echo "  ${ORDERER_IMAGE}"
 echo "  ${COMMITTER_IMAGE}"
 echo "  ${LOADGEN_IMAGE}"
+echo "  ${EXPLORER_IMAGE} (available=${EXPLORER_AVAILABLE})"
 
 # When running in GitHub Actions, write resolved image names to GITHUB_OUTPUT
 # so downstream workflow steps can reference them without parsing stdout.
@@ -259,4 +260,6 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "orderer_image=${ORDERER_IMAGE}" >>"${GITHUB_OUTPUT}"
   echo "committer_image=${COMMITTER_IMAGE}" >>"${GITHUB_OUTPUT}"
   echo "loadgen_image=${LOADGEN_IMAGE}" >>"${GITHUB_OUTPUT}"
+  echo "explorer_image=${EXPLORER_IMAGE}" >>"${GITHUB_OUTPUT}"
+  echo "explorer_available=${EXPLORER_AVAILABLE}" >>"${GITHUB_OUTPUT}"
 fi

--- a/integration/test/build-e2e.sh
+++ b/integration/test/build-e2e.sh
@@ -219,6 +219,27 @@ docker build \
   "${COMMITTER_DIR}"
 
 # ──────────────────────────────────────────────────────────────────────────────
+# Pull explorer image (:latest — independently released, non-blocking)
+# If the pull fails the E2E test continues without the explorer smoke check.
+# ──────────────────────────────────────────────────────────────────────────────
+EXPLORER_IMAGE="${EXPLORER_REPO:-}/${EXPLORER_IMAGE_NAME:-}:latest"
+EXPLORER_AVAILABLE="false"
+if [[ -n "${EXPLORER_REPO:-}" && -n "${EXPLORER_IMAGE_NAME:-}" ]]; then
+  echo "Pulling explorer image: ${EXPLORER_IMAGE}..."
+  if docker pull "${EXPLORER_IMAGE}" 2>/dev/null; then
+    EXPLORER_AVAILABLE="true"
+    echo "  ✅ ${EXPLORER_IMAGE}"
+  else
+    echo "  ⚠️  Explorer image unavailable — smoke check will be skipped"
+  fi
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "explorer_image=${EXPLORER_IMAGE}" >> "${GITHUB_OUTPUT}"
+  echo "explorer_available=${EXPLORER_AVAILABLE}" >> "${GITHUB_OUTPUT}"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────────
 # Summary
 # ──────────────────────────────────────────────────────────────────────────────
 echo ""

--- a/integration/test/docker-compose.yaml
+++ b/integration/test/docker-compose.yaml
@@ -140,7 +140,7 @@ services:
   # ---------------------------------------------------------------------------
   # Minimal Postgres instance used exclusively by the block explorer.
   # The committer uses its own embedded DB; this is a separate instance.
-  # Started only when the explorer smoke check runs (EXPLORER_AVAILABLE=true).
+  # Started as part of the explorer smoke check (step 10).
   postgres:
     image: postgres:16-alpine
     container_name: postgres
@@ -156,12 +156,12 @@ services:
   # ---------------------------------------------------------------------------
   # Connects to the committer sidecar (port 4001, no TLS in this test env)
   # and to the postgres service above. Exposes the REST API on port 8080.
-  # Started only when the explorer smoke check runs (EXPLORER_AVAILABLE=true).
+  # Started as part of the explorer smoke check (step 10).
   #
   # Port mapping:
   #   8080 = REST API + Swagger UI (/docs) + health check (/healthz)
   explorer:
-    image: ${EXPLORER_IMAGE:-ghcr.io/lf-decentralized-trust-labs/fabric-x-block-explorer:latest}
+    image: ${EXPLORER_IMAGE:-localhost/fabric-x-block-explorer:latest}
     container_name: explorer
     command: ["start", "--config", "/config/explorer.yaml"]
     volumes:

--- a/integration/test/docker-compose.yaml
+++ b/integration/test/docker-compose.yaml
@@ -136,6 +136,45 @@ services:
       - e2e
 
   # ---------------------------------------------------------------------------
+  # PostgreSQL (explorer backing store)
+  # ---------------------------------------------------------------------------
+  # Minimal Postgres instance used exclusively by the block explorer.
+  # The committer uses its own embedded DB; this is a separate instance.
+  # Started only when the explorer smoke check runs (EXPLORER_AVAILABLE=true).
+  postgres:
+    image: postgres:16-alpine
+    container_name: postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: explorer
+    networks:
+      - e2e
+
+  # ---------------------------------------------------------------------------
+  # Fabric-X Block Explorer
+  # ---------------------------------------------------------------------------
+  # Connects to the committer sidecar (port 4001, no TLS in this test env)
+  # and to the postgres service above. Exposes the REST API on port 8080.
+  # Started only when the explorer smoke check runs (EXPLORER_AVAILABLE=true).
+  #
+  # Port mapping:
+  #   8080 = REST API + Swagger UI (/docs) + health check (/healthz)
+  explorer:
+    image: ${EXPLORER_IMAGE:-ghcr.io/lf-decentralized-trust-labs/fabric-x-block-explorer:latest}
+    container_name: explorer
+    command: ["start", "--config", "/config/explorer.yaml"]
+    volumes:
+      - ./explorerconfig/explorer.yaml:/config/explorer.yaml
+    ports:
+      - "8080:8080"
+    depends_on:
+      - committer
+      - postgres
+    networks:
+      - e2e
+
+  # ---------------------------------------------------------------------------
   # Prometheus
   # ---------------------------------------------------------------------------
   # Scrapes metrics from all Fabric-X services on the e2e network.

--- a/integration/test/docker-compose.yaml
+++ b/integration/test/docker-compose.yaml
@@ -7,11 +7,15 @@
 # E2E Integration Test - Docker Compose
 # =============================================================================
 #
-# Runs three services on a shared Docker network:
+# Runs services on a shared Docker network:
 #
 #   1. arma      - Arma BFT orderer (4 parties, 1 shard, 16 processes)
 #   2. committer - Committer pipeline (embedded PostgreSQL + 5 microservices)
 #   3. loadgen   - Load generator (submits TXs, receives committed blocks)
+#   4. postgres  - PostgreSQL backing store for the block explorer
+#   5. explorer  - Fabric-X block explorer (REST API + block ingestion)
+#   6. prometheus - Metrics scraping (optional, ENABLE_MONITORING)
+#   7. grafana   - Dashboard UI (optional, ENABLE_MONITORING)
 #
 # Image names are configurable via environment variables (set by run-e2e.sh
 # or build-e2e.sh). Defaults are provided for convenience.
@@ -140,7 +144,7 @@ services:
   # ---------------------------------------------------------------------------
   # Minimal Postgres instance used exclusively by the block explorer.
   # The committer uses its own embedded DB; this is a separate instance.
-  # Started as part of the explorer smoke check (step 10).
+  # Started by step_5_2_start_explorer in run-e2e.sh (skipped when ENABLE_EXPLORER=false).
   postgres:
     image: postgres:16-alpine
     container_name: postgres
@@ -156,12 +160,12 @@ services:
   # ---------------------------------------------------------------------------
   # Connects to the committer sidecar (port 4001, no TLS in this test env)
   # and to the postgres service above. Exposes the REST API on port 8080.
-  # Started as part of the explorer smoke check (step 10).
+  # Started by step_5_2_start_explorer in run-e2e.sh (skipped when ENABLE_EXPLORER=false).
   #
   # Port mapping:
   #   8080 = REST API + Swagger UI (/docs) + health check (/healthz)
   explorer:
-    image: ${EXPLORER_IMAGE:-localhost/fabric-x-block-explorer:latest}
+    image: ${EXPLORER_IMAGE:-localhost/fabric-x-block-explorer}
     container_name: explorer
     command: ["start", "--config", "/config/explorer.yaml"]
     volumes:

--- a/integration/test/explorerconfig/explorer.yaml
+++ b/integration/test/explorerconfig/explorer.yaml
@@ -1,0 +1,42 @@
+#
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Explorer config for the fabric-x E2E integration test.
+# Connects to the committer sidecar (no TLS) and to the postgres service.
+# Mounted at /config/explorer.yaml inside the explorer container.
+---
+database:
+  endpoints:
+    - host: postgres
+      port: 5432
+  user: postgres
+  password: postgres
+  dbname: explorer
+  max_conns: 10
+
+sidecar:
+  connection:
+    endpoint:
+      host: committer
+      port: 4001
+    tls:
+      mode: none
+  start_block: 0
+
+buffer:
+  raw_channel_size: 500
+  proc_channel_size: 500
+
+workers:
+  processor_count: 4
+  writer_count: 4
+
+server:
+  rest:
+    endpoint:
+      host: 0.0.0.0
+      port: 8080
+    read_header_timeout: 10s
+    default_tx_limit: 50

--- a/integration/test/refs.conf
+++ b/integration/test/refs.conf
@@ -22,3 +22,7 @@ COMMITTER_REPO="https://github.com/hyperledger/fabric-x-committer.git"
 ORDERER_IMAGE_NAME="arma-4p1s"
 COMMITTER_IMAGE_NAME="committer-test-node"
 LOADGEN_IMAGE_NAME="fabric-x-loadgen"
+
+# Explorer block explorer image (pulled as :latest — independently released)
+EXPLORER_IMAGE_NAME="fabric-x-block-explorer"
+EXPLORER_REPO="ghcr.io/lf-decentralized-trust-labs"

--- a/integration/test/refs.conf
+++ b/integration/test/refs.conf
@@ -12,13 +12,13 @@
 FABRIC_X_REF="v1.0.0"
 ORDERER_REF="v1.0.0"
 COMMITTER_REF="v1.0.0"
-EXPLORER_REF="latest"
+EXPLORER_REF="v0.1.0"
 
 # repos
 FABRIC_X_REPO="https://github.com/hyperledger/fabric-x.git"
 ORDERER_REPO="https://github.com/hyperledger/fabric-x-orderer.git"
 COMMITTER_REPO="https://github.com/hyperledger/fabric-x-committer.git"
-EXPLORER_REPO="ghcr.io/lf-decentralized-trust-labs"
+EXPLORER_REPO="https://github.com/LF-Decentralized-Trust-labs/fabric-x-block-explorer.git"
 
 # Docker image names (without registry prefix or tag)
 ORDERER_IMAGE_NAME="arma-4p1s"

--- a/integration/test/refs.conf
+++ b/integration/test/refs.conf
@@ -12,17 +12,16 @@
 FABRIC_X_REF="v1.0.0"
 ORDERER_REF="v1.0.0"
 COMMITTER_REF="v1.0.0"
+EXPLORER_REF="latest"
 
 # repos
 FABRIC_X_REPO="https://github.com/hyperledger/fabric-x.git"
 ORDERER_REPO="https://github.com/hyperledger/fabric-x-orderer.git"
 COMMITTER_REPO="https://github.com/hyperledger/fabric-x-committer.git"
+EXPLORER_REPO="ghcr.io/lf-decentralized-trust-labs"
 
 # Docker image names (without registry prefix or tag)
 ORDERER_IMAGE_NAME="arma-4p1s"
 COMMITTER_IMAGE_NAME="committer-test-node"
 LOADGEN_IMAGE_NAME="fabric-x-loadgen"
-
-# Explorer block explorer image (pulled as :latest — independently released)
 EXPLORER_IMAGE_NAME="fabric-x-block-explorer"
-EXPLORER_REPO="ghcr.io/lf-decentralized-trust-labs"

--- a/integration/test/run-e2e.sh
+++ b/integration/test/run-e2e.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # =============================================================================
-# E2E Integration Test: Arma Orderer + Committer Pipeline + Loadgen
+# E2E Integration Test: Arma Orderer + Committer Pipeline + Loadgen + Block Explorer
 # =============================================================================
 set -euo pipefail
 
@@ -20,7 +20,7 @@ dump_failure_logs() {
 
   echo "=== FAILURE: dumping docker compose logs before cleanup ==="
   if [ -f "${SCRIPT_DIR}/docker-compose.yaml" ]; then
-    docker compose -f "${SCRIPT_DIR}/docker-compose.yaml" logs --no-color arma committer loadgen explorer || true
+    docker compose -f "${SCRIPT_DIR}/docker-compose.yaml" logs --no-color arma committer loadgen explorer postgres || true
   fi
 }
 
@@ -37,6 +37,9 @@ cleanup() {
     echo ""
     echo "  Grafana dashboard: http://localhost:3000  (admin/admin)"
     echo "  Prometheus:        http://localhost:9090"
+    if [ "${ENABLE_EXPLORER:-true}" = "true" ]; then
+      echo "  Block explorer:    http://localhost:8080"
+    fi
     echo "============================================================"
     echo ""
     echo "Press ENTER to clean up containers and artifacts, or Ctrl+C to keep them running..."
@@ -110,6 +113,7 @@ FABRIC_X_BIN="${FABRIC_X_BIN:-${DEFAULT_FABRIC_X_BIN}}"
 COMPOSE_FILES=("-f" "${SCRIPT_DIR}/docker-compose.yaml")
 HEALTH_TIMEOUT="120"
 ENABLE_MONITORING="${ENABLE_MONITORING:-true}"
+ENABLE_EXPLORER="${ENABLE_EXPLORER:-true}"
 
 # Validates required host binaries and generated fabric-x tools are present.
 # Fails fast with clear errors to avoid partial E2E setup.
@@ -135,7 +139,7 @@ print_images() {
   echo "  orderer:   ${ORDERER_IMAGE}"
   echo "  committer: ${COMMITTER_IMAGE}"
   echo "  loadgen:   ${LOADGEN_IMAGE}"
-  echo "  explorer:  ${EXPLORER_IMAGE}"
+  echo "  explorer:  ${EXPLORER_IMAGE} (enabled: ${ENABLE_EXPLORER})"
 }
 
 # Cleans stale docker resources and prepares runtime artifact/storage directories.
@@ -327,7 +331,21 @@ step_5_1_start_monitoring() {
   echo "  Prometheus: http://localhost:9090"
 }
 
-# Waits for key Arma/committer ports to become reachable.
+# Starts block explorer and its postgres dependency.
+# Skipped when ENABLE_EXPLORER=false.
+step_5_2_start_explorer() {
+  if [ "${ENABLE_EXPLORER}" != "true" ]; then
+    echo "=== Step 5.2: Explorer disabled (ENABLE_EXPLORER=${ENABLE_EXPLORER}) ==="
+    return 0
+  fi
+
+  echo "=== Step 5.2: Start block explorer (postgres + explorer) ==="
+  docker compose "${COMPOSE_FILES[@]}" up -d postgres explorer
+
+  echo "  Explorer REST API: http://localhost:8080"
+}
+
+# Waits for key Arma/committer/explorer ports to become reachable.
 # Verifies TCP port availability and TLS handshake completion.
 # TLS readiness check ensures services are fully initialized before
 # fxconfig attempts mTLS connections, which can fail if the server's
@@ -378,6 +396,14 @@ step_6_wait_health() {
     docker compose "${COMPOSE_FILES[@]}" logs committer
     exit 1
   }
+
+  if [ "${ENABLE_EXPLORER}" = "true" ]; then
+    wait_for_port 8080 "Explorer REST API" || {
+      echo "Explorer failed to start"
+      docker compose "${COMPOSE_FILES[@]}" logs explorer postgres
+      exit 1
+    }
+  fi
 }
 
 # Creates namespace 0 using multi-org endorsement with fxconfig workflow.
@@ -445,59 +471,6 @@ step_8_run_loadgen() {
   echo "Loadgen exited with code ${LOADGEN_EXIT_CODE} (accepted)"
 }
 
-# Starts the explorer and its postgres dependency, then waits for the REST API.
-# This step is non-blocking: if the service fails to start, a warning is logged
-# and the test continues to a successful exit.
-# The core E2E result (step_9) is not affected by explorer failures.
-step_10_smoke_explorer() {
-  echo "=== Step 10: Explorer smoke check (non-blocking) ==="
-
-  echo "Starting postgres and explorer..."
-  docker compose "${COMPOSE_FILES[@]}" up -d postgres explorer
-
-  echo "Polling explorer /healthz (up to ${HEALTH_TIMEOUT}s)..."
-  local i
-  for ((i = 1; i <= HEALTH_TIMEOUT; i++)); do
-    if curl -sf http://127.0.0.1:8080/healthz >/dev/null 2>&1; then
-      echo "✅ Explorer /healthz is ready"
-      return 0
-    fi
-    sleep 1
-  done
-
-  echo "⚠️  Explorer did not become ready within ${HEALTH_TIMEOUT}s — smoke check skipped"
-  docker compose "${COMPOSE_FILES[@]}" logs --no-color --tail=30 explorer || true
-  return 0  # non-blocking: do not fail the E2E job
-}
-
-# Verifies the explorer has ingested transactions from the committer by polling
-# GET /blocks (summing tx_count fields) until the total reaches >= 10002 or the
-# timeout expires. 10002 = 10000 loadgen TXs + 1 config TX + 1 namespace TX.
-# Non-blocking: a warning is logged on timeout and the test exits successfully.
-step_11_verify_explorer() {
-  echo "=== Step 11: Verify explorer transaction count >= 10002 (non-blocking) ==="
-
-  local i tx_total
-  for ((i = 1; i <= HEALTH_TIMEOUT; i++)); do
-    tx_total=$(curl -sf "http://127.0.0.1:8080/blocks?limit=10000" 2>/dev/null \
-      | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-print(sum(b.get('tx_count', 0) for b in data.get('blocks', [])))
-" 2>/dev/null \
-      || echo 0)
-    if [ "${tx_total:-0}" -ge 10002 ]; then
-      echo "✅ Explorer has ingested ${tx_total} transactions (>= 10002)"
-      return 0
-    fi
-    sleep 2
-  done
-
-  echo "⚠️  Explorer transaction count did not reach 10002 within ${HEALTH_TIMEOUT}s — smoke check inconclusive"
-  docker compose "${COMPOSE_FILES[@]}" logs --no-color --tail=30 explorer || true
-  return 0  # non-blocking: do not fail the E2E job
-}
-
 # Queries VC Prometheus metrics over mTLS to read committed tx count.
 # Enforces minimum threshold and dumps logs on verification failure.
 step_9_verify_results() {
@@ -520,6 +493,62 @@ step_9_verify_results() {
   fi
 }
 
+# Waits for the explorer REST API /healthz endpoint to become ready.
+# Mirrors the wait_for_port pattern: returns 1 on timeout so callers can
+# apply the same "|| { log; exit 1 }" handling used by step_6_wait_health.
+wait_for_explorer_health() {
+  echo "Waiting for explorer /healthz (up to ${HEALTH_TIMEOUT}s)..."
+  local i
+  for ((i = 1; i <= HEALTH_TIMEOUT; i++)); do
+    if curl -sf http://127.0.0.1:8080/healthz >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+# Waits for the explorer REST API to become healthy, then verifies it has
+# ingested all expected transactions (>= 10002).
+# Skipped when ENABLE_EXPLORER=false.
+# 10002 = 10000 loadgen TXs + 1 config TX + 1 namespace TX.
+step_10_verify_explorer() {
+  if [ "${ENABLE_EXPLORER}" != "true" ]; then
+    echo "=== Step 10: Explorer verification skipped (ENABLE_EXPLORER=${ENABLE_EXPLORER}) ==="
+    return 0
+  fi
+
+  echo "=== Step 10: Verify block explorer ==="
+
+  wait_for_explorer_health || {
+    echo "Explorer failed to become ready within ${HEALTH_TIMEOUT}s"
+    docker compose "${COMPOSE_FILES[@]}" logs --no-color --tail=50 explorer postgres
+    exit 1
+  }
+  echo "Explorer /healthz is ready"
+
+  echo "Polling explorer transaction count (>= 10002, up to ${HEALTH_TIMEOUT}s)..."
+  local i tx_total
+  for ((i = 1; i <= HEALTH_TIMEOUT; i++)); do
+    tx_total=$(curl -sf "http://127.0.0.1:8080/blocks?limit=10000" 2>/dev/null \
+      | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(sum(b.get('tx_count', 0) for b in data.get('blocks', [])))
+" 2>/dev/null \
+      || echo 0)
+    if [ "${tx_total:-0}" -ge 10002 ]; then
+      echo "SUCCESS: Explorer has ingested ${tx_total} transactions (>= 10002)"
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "FAILURE: Explorer transaction count did not reach 10002 within ${HEALTH_TIMEOUT}s (got ${tx_total:-0})"
+  docker compose "${COMPOSE_FILES[@]}" logs --no-color --tail=50 explorer postgres
+  exit 1
+}
+
 # Orchestrates the full E2E lifecycle in deterministic step order.
 # Keeps control flow concise and makes each phase easy to locate.
 main() {
@@ -532,12 +561,12 @@ main() {
   step_4_generate_config_block
   step_5_start_services
   step_5_1_start_monitoring
+  step_5_2_start_explorer
   step_6_wait_health
   step_7_create_namespace
   step_8_run_loadgen
   step_9_verify_results
-  step_10_smoke_explorer
-  step_11_verify_explorer
+  step_10_verify_explorer
 }
 
 main "$@"

--- a/integration/test/run-e2e.sh
+++ b/integration/test/run-e2e.sh
@@ -20,7 +20,7 @@ dump_failure_logs() {
 
   echo "=== FAILURE: dumping docker compose logs before cleanup ==="
   if [ -f "${SCRIPT_DIR}/docker-compose.yaml" ]; then
-    docker compose -f "${SCRIPT_DIR}/docker-compose.yaml" logs --no-color arma committer loadgen || true
+    docker compose -f "${SCRIPT_DIR}/docker-compose.yaml" logs --no-color arma committer loadgen explorer || true
   fi
 }
 
@@ -104,6 +104,11 @@ source "${REFS_CONF}"
 export ORDERER_IMAGE="${ORDERER_IMAGE:-docker.io/hyperledger/${ORDERER_IMAGE_NAME}:${ORDERER_REF}}"
 export COMMITTER_IMAGE="${COMMITTER_IMAGE:-docker.io/hyperledger/${COMMITTER_IMAGE_NAME}:${COMMITTER_REF}}"
 export LOADGEN_IMAGE="${LOADGEN_IMAGE:-docker.io/hyperledger/${LOADGEN_IMAGE_NAME}:${COMMITTER_REF}}"
+export EXPLORER_IMAGE="${EXPLORER_IMAGE:-${EXPLORER_REPO:-}/${EXPLORER_IMAGE_NAME:-}:latest}"
+# EXPLORER_AVAILABLE is set to "true" by build-e2e.sh when the image was
+# successfully pulled. Default to "false" so the smoke check is skipped
+# when run-e2e.sh is invoked standalone without build-e2e.sh.
+EXPLORER_AVAILABLE="${EXPLORER_AVAILABLE:-false}"
 FABRIC_X_BIN="${FABRIC_X_BIN:-${DEFAULT_FABRIC_X_BIN}}"
 
 COMPOSE_FILES=("-f" "${SCRIPT_DIR}/docker-compose.yaml")
@@ -134,6 +139,7 @@ print_images() {
   echo "  orderer:   ${ORDERER_IMAGE}"
   echo "  committer: ${COMMITTER_IMAGE}"
   echo "  loadgen:   ${LOADGEN_IMAGE}"
+  echo "  explorer:  ${EXPLORER_IMAGE} (available=${EXPLORER_AVAILABLE})"
 }
 
 # Cleans stale docker resources and prepares runtime artifact/storage directories.
@@ -443,6 +449,63 @@ step_8_run_loadgen() {
   echo "Loadgen exited with code ${LOADGEN_EXIT_CODE} (accepted)"
 }
 
+# Starts the explorer and its postgres dependency, then waits for the REST API.
+# This step is non-blocking: if the image is unavailable or the service fails
+# to start, a warning is logged and the test continues to a successful exit.
+# The core E2E result (step_9) is not affected by explorer failures.
+step_10_smoke_explorer() {
+  echo "=== Step 10: Explorer smoke check (non-blocking) ==="
+
+  if [[ "${EXPLORER_AVAILABLE}" != "true" ]]; then
+    echo "⏭️  Explorer image not available — skipping smoke check"
+    return 0
+  fi
+
+  echo "Starting postgres and explorer..."
+  docker compose "${COMPOSE_FILES[@]}" up -d postgres explorer
+
+  echo "Polling explorer /healthz (up to ${HEALTH_TIMEOUT}s)..."
+  local i
+  for ((i = 1; i <= HEALTH_TIMEOUT; i++)); do
+    if curl -sf http://127.0.0.1:8080/healthz >/dev/null 2>&1; then
+      echo "✅ Explorer /healthz is ready"
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "⚠️  Explorer did not become ready within ${HEALTH_TIMEOUT}s — smoke check skipped"
+  docker compose "${COMPOSE_FILES[@]}" logs --no-color --tail=30 explorer || true
+  return 0  # non-blocking: do not fail the E2E job
+}
+
+# Verifies the explorer has ingested at least one block from the committer.
+# Non-blocking: a warning is logged on timeout and the test exits successfully.
+step_11_verify_explorer() {
+  echo "=== Step 11: Verify explorer ingested blocks (non-blocking) ==="
+
+  if [[ "${EXPLORER_AVAILABLE}" != "true" ]]; then
+    echo "⏭️  Explorer not available — skipping block ingestion check"
+    return 0
+  fi
+
+  local i height
+  for ((i = 1; i <= HEALTH_TIMEOUT; i++)); do
+    height=$(curl -sf http://127.0.0.1:8080/blocks/height 2>/dev/null \
+      | python3 -c "import json,sys; print(json.load(sys.stdin).get('height', 0))" 2>/dev/null \
+      || echo 0)
+    if [ "${height:-0}" -gt 0 ]; then
+      echo "✅ Explorer has ingested ${height} block(s)"
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "⚠️  Explorer block height never rose above 0 — smoke check inconclusive"
+  docker compose "${COMPOSE_FILES[@]}" logs --no-color --tail=30 explorer || true
+  return 0  # non-blocking: do not fail the E2E job
+}
+
 # Queries VC Prometheus metrics over mTLS to read committed tx count.
 # Enforces minimum threshold and dumps logs on verification failure.
 step_9_verify_results() {
@@ -481,6 +544,8 @@ main() {
   step_7_create_namespace
   step_8_run_loadgen
   step_9_verify_results
+  step_10_smoke_explorer
+  step_11_verify_explorer
 }
 
 main "$@"

--- a/integration/test/run-e2e.sh
+++ b/integration/test/run-e2e.sh
@@ -104,11 +104,7 @@ source "${REFS_CONF}"
 export ORDERER_IMAGE="${ORDERER_IMAGE:-docker.io/hyperledger/${ORDERER_IMAGE_NAME}:${ORDERER_REF}}"
 export COMMITTER_IMAGE="${COMMITTER_IMAGE:-docker.io/hyperledger/${COMMITTER_IMAGE_NAME}:${COMMITTER_REF}}"
 export LOADGEN_IMAGE="${LOADGEN_IMAGE:-docker.io/hyperledger/${LOADGEN_IMAGE_NAME}:${COMMITTER_REF}}"
-export EXPLORER_IMAGE="${EXPLORER_IMAGE:-${EXPLORER_REPO:-}/${EXPLORER_IMAGE_NAME:-}:latest}"
-# EXPLORER_AVAILABLE is set to "true" by build-e2e.sh when the image was
-# successfully pulled. Default to "false" so the smoke check is skipped
-# when run-e2e.sh is invoked standalone without build-e2e.sh.
-EXPLORER_AVAILABLE="${EXPLORER_AVAILABLE:-false}"
+export EXPLORER_IMAGE="${EXPLORER_IMAGE:-localhost/${EXPLORER_IMAGE_NAME}:${EXPLORER_REF}}"
 FABRIC_X_BIN="${FABRIC_X_BIN:-${DEFAULT_FABRIC_X_BIN}}"
 
 COMPOSE_FILES=("-f" "${SCRIPT_DIR}/docker-compose.yaml")
@@ -139,7 +135,7 @@ print_images() {
   echo "  orderer:   ${ORDERER_IMAGE}"
   echo "  committer: ${COMMITTER_IMAGE}"
   echo "  loadgen:   ${LOADGEN_IMAGE}"
-  echo "  explorer:  ${EXPLORER_IMAGE} (available=${EXPLORER_AVAILABLE})"
+  echo "  explorer:  ${EXPLORER_IMAGE}"
 }
 
 # Cleans stale docker resources and prepares runtime artifact/storage directories.
@@ -450,16 +446,11 @@ step_8_run_loadgen() {
 }
 
 # Starts the explorer and its postgres dependency, then waits for the REST API.
-# This step is non-blocking: if the image is unavailable or the service fails
-# to start, a warning is logged and the test continues to a successful exit.
+# This step is non-blocking: if the service fails to start, a warning is logged
+# and the test continues to a successful exit.
 # The core E2E result (step_9) is not affected by explorer failures.
 step_10_smoke_explorer() {
   echo "=== Step 10: Explorer smoke check (non-blocking) ==="
-
-  if [[ "${EXPLORER_AVAILABLE}" != "true" ]]; then
-    echo "⏭️  Explorer image not available — skipping smoke check"
-    return 0
-  fi
 
   echo "Starting postgres and explorer..."
   docker compose "${COMPOSE_FILES[@]}" up -d postgres explorer
@@ -479,29 +470,30 @@ step_10_smoke_explorer() {
   return 0  # non-blocking: do not fail the E2E job
 }
 
-# Verifies the explorer has ingested at least one block from the committer.
+# Verifies the explorer has ingested transactions from the committer by polling
+# GET /blocks (summing tx_count fields) until the total reaches >= 10002 or the
+# timeout expires. 10002 = 10000 loadgen TXs + 1 config TX + 1 namespace TX.
 # Non-blocking: a warning is logged on timeout and the test exits successfully.
 step_11_verify_explorer() {
-  echo "=== Step 11: Verify explorer ingested blocks (non-blocking) ==="
+  echo "=== Step 11: Verify explorer transaction count >= 10002 (non-blocking) ==="
 
-  if [[ "${EXPLORER_AVAILABLE}" != "true" ]]; then
-    echo "⏭️  Explorer not available — skipping block ingestion check"
-    return 0
-  fi
-
-  local i height
+  local i tx_total
   for ((i = 1; i <= HEALTH_TIMEOUT; i++)); do
-    height=$(curl -sf http://127.0.0.1:8080/blocks/height 2>/dev/null \
-      | python3 -c "import json,sys; print(json.load(sys.stdin).get('height', 0))" 2>/dev/null \
+    tx_total=$(curl -sf "http://127.0.0.1:8080/blocks?limit=10000" 2>/dev/null \
+      | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(sum(b.get('tx_count', 0) for b in data.get('blocks', [])))
+" 2>/dev/null \
       || echo 0)
-    if [ "${height:-0}" -gt 0 ]; then
-      echo "✅ Explorer has ingested ${height} block(s)"
+    if [ "${tx_total:-0}" -ge 10002 ]; then
+      echo "✅ Explorer has ingested ${tx_total} transactions (>= 10002)"
       return 0
     fi
     sleep 2
   done
 
-  echo "⚠️  Explorer block height never rose above 0 — smoke check inconclusive"
+  echo "⚠️  Explorer transaction count did not reach 10002 within ${HEALTH_TIMEOUT}s — smoke check inconclusive"
   docker compose "${COMPOSE_FILES[@]}" logs --no-color --tail=30 explorer || true
   return 0  # non-blocking: do not fail the E2E job
 }
@@ -519,10 +511,10 @@ step_9_verify_results() {
 
   echo "Committed transactions: ${COMMITTED_TXS}"
 
-  if [ "${COMMITTED_TXS:-0}" -ge 5000 ]; then
+  if [ "${COMMITTED_TXS:-0}" -ge 10002 ]; then
     echo "SUCCESS: E2E test passed (${COMMITTED_TXS} transactions committed)"
   else
-    echo "FAILURE: Expected >= 5000 committed transactions, got ${COMMITTED_TXS:-0}"
+    echo "FAILURE: Expected >= 10002 committed transactions, got ${COMMITTED_TXS:-0}"
     docker compose "${COMPOSE_FILES[@]}" logs
     exit 1
   fi


### PR DESCRIPTION
#### Type of change

- Test update

#### Description

Adds a non-blocking block explorer smoke check to the E2E integration test.

The explorer (`ghcr.io/lf-decentralized-trust-labs/fabric-x-block-explorer:latest`)
is an independently released component — it is not co-versioned with `fabric-x`.
The integration follows these principles:

- The image is **pulled as `:latest`** from GHCR in `build-e2e.sh` (best-effort).
  If the pull fails the core E2E test is unaffected.
- Two new non-blocking steps are added to `run-e2e.sh` after `step_9_verify_results`:
  - **Step 10** — starts `postgres` + `explorer` compose services, polls `/healthz`
  - **Step 11** — polls `GET /blocks/height` to confirm at least one block was ingested
- Both steps always return `0`. `step_9_verify_results` owns the pass/fail decision.
- No changes to `.github/workflows/e2e.yml` — it delegates fully to the shell scripts.

**Files changed:**
- `integration/test/refs.conf` — added `EXPLORER_IMAGE_NAME` + `EXPLORER_REPO`
- `integration/test/build-e2e.sh` — best-effort image pull, writes `explorer_available` to `GITHUB_OUTPUT`
- `integration/test/docker-compose.yaml` — added `postgres` and `explorer` services
- `integration/test/explorerconfig/explorer.yaml` — new explorer config (DB + sidecar + REST)
- `integration/test/run-e2e.sh` — added `step_10_smoke_explorer`, `step_11_verify_explorer`
- `integration/test/README.md` — updated image table, steps list, directory structure

#### Related issues

https://github.com/LF-Decentralized-Trust-labs/fabric-x-block-explorer/issues/18
