### PR TITLE
Added release-bins flow to release binaries in `*.tar.gz` archive on release tag

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,113 @@
+#
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+name: Release Binaries
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v1.0.0). Re-runs an existing release."
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    name: Validate Tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.extract.outputs.tag }}
+      version: ${{ steps.extract.outputs.version }}
+    steps:
+      - name: Extract and validate version from tag
+        id: extract
+        env:
+          RAW_TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          if [[ "${RAW_TAG}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+.*)$ ]]; then
+            echo "tag=${RAW_TAG}" >> "$GITHUB_OUTPUT"
+            echo "version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+            echo "✅ Tag validated: ${RAW_TAG}"
+          else
+            echo "❌ Invalid tag format: ${RAW_TAG}. Expected format: v<semver>"
+            exit 1
+          fi
+
+  build:
+    name: Build (${{ matrix.os }}/${{ matrix.arch }})
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            arch: amd64
+          - os: linux
+            arch: arm64
+          - os: linux
+            arch: s390x
+          - os: darwin
+            arch: amd64
+          - os: darwin
+            arch: arm64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build and package binaries
+        env:
+          TARGET: ${{ matrix.os }}-${{ matrix.arch }}
+          RELEASE: ${{ needs.prepare.outputs.tag }}
+          REVISION: ${{ github.sha }}
+        run: ./scripts/create-binary-package.sh
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: fabric-x-tools-${{ matrix.os }}-${{ matrix.arch }}
+          path: release/*/fabric-x-tools-*.tar.gz
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub Release
+    needs:
+      - prepare
+      - build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Generate checksums
+        working-directory: dist
+        run: sha256sum *.tar.gz > checksums.txt
+
+      - name: Publish release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          files: |
+            dist/*.tar.gz
+            dist/checksums.txt
+          fail_on_unmatched_files: true

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: fabric-x-tools-${{ matrix.os }}-${{ matrix.arch }}
-          path: release/*/fabric-x-tools-*.tar.gz
+          path: release/${{ matrix.os }}-${{ matrix.arch }}/fabric-x-tools-*.tar.gz
           if-no-files-found: error
 
   release:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bin
+/release
 
 # VSCode
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,25 @@ $(BUILD_DIR)/%:
 	@GOBIN=$(abspath $(@D)) go install -tags "$(GO_TAGS)" -ldflags "$(GO_LDFLAGS)" -buildvcs=false $(pkgmap.$(@F))
 	@touch $@
 
+RELEASE_DIR ?= release
+GOOS   ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+RELEASE_BIN_DIR = $(RELEASE_DIR)/$(GOOS)-$(GOARCH)/bin
+
+.PHONY: release-bins
+release-bins: $(TOOLS_EXES:%=$(RELEASE_BIN_DIR)/%) ## Cross-compiles all tools for $(GOOS)/$(GOARCH) into $(RELEASE_DIR)
+
+$(RELEASE_DIR)/%: GO_LDFLAGS = $(METADATA_VAR:%=-X $(PKGNAME)/common/metadata.%)
+$(RELEASE_DIR)/%:
+	@echo "Building $@"
+	@mkdir -p $(@D)
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(go_cmd) build -trimpath \
+		-tags "$(GO_TAGS)" -ldflags "$(GO_LDFLAGS)" -buildvcs=false \
+		-o $@ $(pkgmap.$(@F))
+
 .PHONY: clean
 clean: ## Cleans the build area
-	-@rm -rf $(BUILD_DIR)
+	-@rm -rf $(BUILD_DIR) $(RELEASE_DIR)
 
 # Run lint
 # TODO: fix existing lint issues (to find them, remove --new-from-rev=origin/main option)

--- a/scripts/create-binary-package.sh
+++ b/scripts/create-binary-package.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+#
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Cross-compiles the Fabric-X CLI tools for a single OS/arch and packages
+# them into a versioned tarball under release/<TARGET>/.
+#
+# Required env vars:
+#   TARGET   <os>-<arch>, e.g. linux-amd64, darwin-arm64
+#   RELEASE  git tag, e.g. v1.0.0
+# Optional env vars:
+#   REVISION commit SHA (defaults to `git rev-parse HEAD`)
+#
+# Usage:
+#   TARGET=darwin-arm64 RELEASE=v1.0.0 ./scripts/create-binary-package.sh
+
+# Exit on error/unset var/pipeline failure.
+set -euo pipefail
+
+# Fail fast with a clear message if TARGET or RELEASE aren't set.
+: "${TARGET:?TARGET is required, e.g. TARGET=linux-amd64}"
+: "${RELEASE:?RELEASE is required, e.g. RELEASE=v1.0.0}"
+
+# Default REVISION to the current commit SHA if not passed in.
+REVISION="${REVISION:-$(git rev-parse HEAD)}"
+
+# Split TARGET (e.g. "linux-amd64") into GOOS and GOARCH.
+if [[ ! "$TARGET" =~ ^([a-z0-9]+)-([a-z0-9]+)$ ]]; then
+  echo "ERROR: TARGET must be in <os>-<arch> form, got: ${TARGET}" >&2
+  exit 1
+fi
+GOOS="${BASH_REMATCH[1]}"
+GOARCH="${BASH_REMATCH[2]}"
+
+# Trim the leading 'v' from the tag, matching build-image.yml's version extraction.
+VERSION="${RELEASE#v}"
+
+# Cross-compile via the Makefile, stamping version/commit into the binaries.
+RELEASE_DIR="release/${TARGET}"
+echo "Building ${TARGET} binaries for ${RELEASE} (${REVISION})..."
+make release-bins GOOS="${GOOS}" GOARCH="${GOARCH}" RELEASE_DIR=release \
+  METADATA_VAR="Version=${VERSION} CommitSHA=${REVISION}"
+
+# Ship the license alongside the binaries.
+cp LICENSE "${RELEASE_DIR}/"
+
+# -C cds into RELEASE_DIR first, so the archive holds relative paths (bin/, LICENSE).
+ARCHIVE="fabric-x-tools-${TARGET}-${VERSION}.tar.gz"
+tar -czf "${RELEASE_DIR}/${ARCHIVE}" -C "${RELEASE_DIR}" bin LICENSE
+
+echo "${RELEASE_DIR}/${ARCHIVE}"


### PR DESCRIPTION
#### Type of change

- New feature
- Documentation update

#### Description

Ship prebuilt `fabric-x-tools` CLI binaries (`configtxgen`, `configtxlator`, `cryptogen`, `fxconfig`) as GitHub Release assets whenever a `v*` tag is pushed, mirroring the existing `fabric-x-tools` image release but for users who don't want to run a container.

None of the four tools depend on cgo, so all platforms cross-compile from a single `ubuntu-latest` runner (no QEMU, no macOS runner needed):

- `linux/amd64`, `linux/arm64`, `linux/s390x` — same as the `fabric-x-tools` image
- `darwin/amd64`, `darwin/arm64` — for macOS users, since the image only ever runs on Linux

Changes:
- `Makefile`: new `release-bins` target that cross-compiles the tools via `go build` (the existing `bin/%` rule uses `go install`, which can't cross-compile) and stamps `Version`/`CommitSHA` via `METADATA_VAR` — previously unused, so released binaries now report their real version instead of `latest`.
- `scripts/create-binary-package.sh`: builds one `<os>-<arch>` target and packages it into `fabric-x-tools-<target>-<version>.tar.gz` (bin/ + LICENSE).
- `.github/workflows/release-binaries.yml`: new workflow, independent of `build-image.yml`. Validates the tag, builds the 5-platform matrix, generates `checksums.txt`, and publishes everything to the tag's GitHub Release via `softprops/action-gh-release@v2` (same action used by the `fabric-x-ansible-collection` release workflow). Also supports manual re-runs via `workflow_dispatch`.