### PR TITLE
fix: explorer e2e build — run make build-release and use correct Dockerfile path

### DIFF
--- a/integration/test/build-e2e.sh
+++ b/integration/test/build-e2e.sh
@@ -260,9 +260,17 @@ if [ "${ENABLE_EXPLORER}" = "true" ]; then
   EXPLORER_DIR="${BUILD_DIR}/fabric-x-block-explorer"
   checkout_source "${EXPLORER_REPO}" "${EXPLORER_REF}" "${EXPLORER_DIR}" "${EXPLORER_LOCAL_PATH:-}" "fabric-x-block-explorer"
 
+  # The release Dockerfile expects pre-built binaries under release/linux-<arch>/.
+  # Run make build-release first to produce them, then build the image.
+  echo "Building explorer release binaries in ${EXPLORER_DIR}..."
+  make -C "${EXPLORER_DIR}" build-release
+
   EXPLORER_IMAGE="localhost/${EXPLORER_IMAGE_NAME}:${EXPLORER_REF}"
   echo "Building ${EXPLORER_IMAGE_NAME} image from ${EXPLORER_DIR}..."
-  docker build -t "${EXPLORER_IMAGE}" "${EXPLORER_DIR}"
+  docker build \
+    -t "${EXPLORER_IMAGE}" \
+    -f "${EXPLORER_DIR}/docker/images/release/Dockerfile" \
+    "${EXPLORER_DIR}"
 else
   echo "=== Skipping explorer build (ENABLE_EXPLORER=${ENABLE_EXPLORER}) ==="
 fi

--- a/integration/test/refs.conf
+++ b/integration/test/refs.conf
@@ -12,7 +12,7 @@
 FABRIC_X_REF="v1.0.0"
 ORDERER_REF="v1.0.0"
 COMMITTER_REF="v1.0.0"
-EXPLORER_REF="v0.1.0"
+EXPLORER_REF="v0.1.1"
 
 # repos
 FABRIC_X_REPO="https://github.com/hyperledger/fabric-x.git"


### PR DESCRIPTION
## Problem

The E2E test (`build-e2e.sh`) was failing for the block explorer for two reasons:

### 1. Wrong Dockerfile path
The explorer repo has **no root `Dockerfile`**. The release image must be built from:
```
docker/images/release/Dockerfile
```
The previous code did `docker build -t "${EXPLORER_IMAGE}" "${EXPLORER_DIR}"` with no `-f` flag, so Docker looked for a root `Dockerfile` that doesn't exist.

### 2. Missing `make build-release` step
The [`docker/images/release/Dockerfile`](https://github.com/LF-Decentralized-Trust-labs/fabric-x-block-explorer/blob/main/docker/images/release/Dockerfile) does **not** compile the Go binary itself — it COPYs a pre-built binary from `release/linux-${TARGETARCH}/explorer`. This binary is produced by `make build-release` in the explorer repo. Without running that step first, the Docker build fails with a missing file error.

### 3. `EXPLORER_REF` pinned to old `v0.1.0`
`refs.conf` still pointed at `v0.1.0`. `v0.1.1` is the first release with:
- `linux/s390x` platform support
- The correct `node:22-alpine` base image (fixes the multi-platform build)

## Fix

**`integration/test/build-e2e.sh`** — in the explorer build section:
```bash
# Before (broken):
docker build -t "${EXPLORER_IMAGE}" "${EXPLORER_DIR}"

# After (fixed):
make -C "${EXPLORER_DIR}" build-release
docker build \
  -t "${EXPLORER_IMAGE}" \
  -f "${EXPLORER_DIR}/docker/images/release/Dockerfile" \
  "${EXPLORER_DIR}"
```

**`integration/test/refs.conf`** — bump explorer ref:
```diff
-EXPLORER_REF="v0.1.0"
+EXPLORER_REF="v0.1.1"
```